### PR TITLE
[FIX] partner_id on return picking is logically the claim partner_id

### DIFF
--- a/crm_claim_rma/wizard/claim_make_picking.py
+++ b/crm_claim_rma/wizard/claim_make_picking.py
@@ -211,7 +211,7 @@ class claim_make_picking(orm.TransientModel):
              'move_type': 'one',  # direct
              'state': 'draft',
              'date': time.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
-             'partner_id': partner_id,
+             'partner_id': claim.partner_id.id,
              'invoice_state': "none",
              'company_id': claim.company_id.id,
              'location_id': wizard.claim_line_source_location.id,


### PR DESCRIPTION
Original Launchpad proposal : https://code.launchpad.net/~camptocamp/openerp-rma/7.0-crm_claim_rma-fix-lp1317045_rde/+merge/218595

It sets the correct partner_id on picking when we generate a new product return from a claim.
