### PR TITLE
CRM Claim Number (partial port of CRM Claim RMA to v8)

### DIFF
--- a/__unported__/crm_claim_rma/__openerp__.py
+++ b/__unported__/crm_claim_rma/__openerp__.py
@@ -74,6 +74,7 @@ Contributors:
     'depends': ['sale',
                 'stock',
                 'crm_claim',
+                'crm_claim_number',
                 'product_warranty',
                 ],
     'data': ['wizard/claim_make_picking_view.xml',

--- a/__unported__/crm_claim_rma/crm_claim_rma_data.xml
+++ b/__unported__/crm_claim_rma/crm_claim_rma_data.xml
@@ -1,19 +1,6 @@
 <?xml version="1.0"?>
 <openerp>
     <data noupdate="1">
-	<!-- Claims Sequence n° -->
-	<record id="seq_type_claim" model="ir.sequence.type">
-            <field name="name">CRM Claim</field>
-            <field name="code">crm.claim.rma</field>
-        </record>
-
-        <record id="seq_claim" model="ir.sequence">
-            <field name="name">CRM Claim</field>
-            <field name="code">crm.claim.rma</field>
-            <field eval="5" name="padding"/>
-            <field name="prefix">RMA-%(year)s/</field>
-        </record>
-	
         <!--
 	    Claim sections
         -->

--- a/__unported__/crm_claim_rma/crm_claim_rma_view.xml
+++ b/__unported__/crm_claim_rma/crm_claim_rma_view.xml
@@ -140,9 +140,6 @@
             <field name="stage_id" position="after">
                 <field name="section_id" />
             </field>
-            <field name="name" position="before">
-                <field name="number" />
-            </field>
         </field>
     </record>
 
@@ -320,10 +317,6 @@
                     <field name="warehouse_id" on_change="onchange_invoice_id(invoice_id, warehouse_id, claim_type, date, company_id, claim_line_ids, False, context)"/>
                 </field>
                 <field name="name" position="replace">
-                    <div class="oe_title">
-                        <label for="number" class="oe_edit_only"/>
-                        <h1><field name="number"/></h1>
-                    </div>
                 </field>
                 <field name="date" position="replace">
                 </field>
@@ -379,9 +372,6 @@
         <field name="model">crm.claim</field>
         <field name="inherit_id" ref="crm_claim.view_crm_case_claims_filter"/>
         <field name="arch" type="xml">
-            <field name="name" string="Claims" position="before">
-                <field name="number"/>
-            </field>
             <filter string="Stage" icon="terp-stage" domain="[]" context="{'group_by':'stage_id'}" position="before">
                 <filter string="Sales Team" icon="terp-stock_symbol-selection" domain="[]" context="{'group_by':'section_id'}"/>
             </filter>

--- a/crm_claim_number/README.rst
+++ b/crm_claim_number/README.rst
@@ -1,0 +1,48 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Claim Number
+============
+
+This module adds a unique number to each Customer Claim.
+
+Installation and configuration
+==============================
+
+You can configure the number format on the CRM Claim sequence
+(Settings/Sequences & Identifiers/Sequence Codes)
+
+Usage
+=====
+
+All new claims will get a new identifier assigned.
+
+Known issues / Roadmap
+======================
+
+* Any preexisting claims already in the system when the module is installed
+  will only have a number assigned.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Joël Grand-Guillaume <joel.grandguillaume@gmail.com>
+* Ondřej Kuzník <ondrej.kuznik@credativ.co.uk>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/crm_claim_number/__init__.py
+++ b/crm_claim_number/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2013 Camptocamp
+#    Copyright 2009-2013 Akretion,
+#    Author: Emmanuel Samyn, Raphaël Valyi, Sébastien Beau,
+#            Joel Grand-Guillaume
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import crm_claim

--- a/crm_claim_number/__openerp__.py
+++ b/crm_claim_number/__openerp__.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2013 Camptocamp
+#    Copyright 2009-2013 Akretion,
+#    Author: Emmanuel Samyn, Raphaël Valyi, Sébastien Beau,
+#            Benoît Guillot, Joel Grand-Guillaume
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Claim number',
+    'version': '1.0',
+    'category': 'Generic Modules/CRM & SRM',
+    'author': "Akretion, Camptocamp,Odoo Community Association (OCA)",
+    'website': 'http://www.akretion.com, http://www.camptocamp.com',
+    'license': 'AGPL-3',
+    'depends': ['crm_claim'],
+    'data': ['crm_claim_view.xml',
+             'crm_claim_data.xml',
+             ],
+    'installable': True,
+    'auto_install': False,
+}

--- a/crm_claim_number/crm_claim.py
+++ b/crm_claim_number/crm_claim.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright 2013 Camptocamp
+#    Copyright 2009-2013 Akretion,
+#    Author: Emmanuel Samyn, Raphaël Valyi, Sébastien Beau,
+#            Benoît Guillot, Joel Grand-Guillaume
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import fields, orm
+
+
+# TODO add the option to split the claim_line in order to manage the same
+# product separately
+class crm_claim(orm.Model):
+    _inherit = 'crm.claim'
+
+    def init(self, cr):
+        cr.execute("""
+            UPDATE "crm_claim" SET "number"=id::varchar
+            WHERE ("number" is NULL)
+               OR ("number" = '/');
+        """)
+
+    def _get_sequence_number(self, cr, uid, context=None):
+        seq_obj = self.pool.get('ir.sequence')
+        res = seq_obj.get(cr, uid, 'crm.claim', context=context) or '/'
+        return res
+
+    def name_get(self, cr, uid, ids, context=None):
+        res = []
+        if isinstance(ids, (int, long)):
+            ids = [ids]
+        for claim in self.browse(cr, uid, ids, context=context):
+            number = claim.number and str(claim.number) or ''
+            res.append((claim.id, '[' + number + '] ' + claim.name))
+        return res
+
+    def create(self, cr, uid, vals, context=None):
+        if ('number' not in vals) or (vals.get('number') == '/'):
+            vals['number'] = self._get_sequence_number(cr, uid,
+                                                       context=context)
+        new_id = super(crm_claim, self).create(cr, uid, vals, context=context)
+        return new_id
+
+    def copy_data(self, cr, uid, id, default=None, context=None):
+        if default is None:
+            default = {}
+        std_default = {
+            'number': self._get_sequence_number(cr, uid, context=context),
+        }
+        std_default.update(default)
+        return super(crm_claim, self).copy_data(
+            cr, uid, id, default=std_default, context=context)
+
+    _columns = {
+        'number': fields.char(
+            'Number', readonly=True, required=True, select=True,
+            help="Company internal claim unique number"),
+    }
+
+    _defaults = {
+        'number': '/',
+    }
+
+    _sql_constraints = [
+        ('number_uniq', 'unique(number, company_id)',
+         'Number/Reference must be unique per Company!'),
+    ]

--- a/crm_claim_number/crm_claim.py
+++ b/crm_claim_number/crm_claim.py
@@ -29,12 +29,16 @@ from openerp.osv import fields, orm
 class crm_claim(orm.Model):
     _inherit = 'crm.claim'
 
-    def init(self, cr):
-        cr.execute("""
-            UPDATE "crm_claim" SET "number"=id::varchar
-            WHERE ("number" is NULL)
-               OR ("number" = '/');
-        """)
+    def _set_default_value_on_column(self, cr, column_name, context=None):
+        if column_name == 'number':
+            cr.execute("""
+                UPDATE "crm_claim" SET "number"=id::varchar
+                WHERE ("number" is NULL)
+                   OR ("number" = '/');
+            """)
+        else:
+            super(crm_claim, self)._set_default_value_on_column(
+                cr, column_name, context=context)
 
     def _get_sequence_number(self, cr, uid, context=None):
         seq_obj = self.pool.get('ir.sequence')

--- a/crm_claim_number/crm_claim_data.xml
+++ b/crm_claim_number/crm_claim_data.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<openerp>
+    <data noupdate="1">
+	<!-- Claims Sequence n° -->
+	<record id="seq_type_claim" model="ir.sequence.type">
+            <field name="name">CRM Claim</field>
+            <field name="code">crm.claim</field>
+        </record>
+
+        <record id="seq_claim" model="ir.sequence">
+            <field name="name">CRM Claim</field>
+            <field name="code">crm.claim</field>
+            <field eval="5" name="padding"/>
+            <field name="prefix">Claim-%(year)s/</field>
+        </record>
+    </data>
+</openerp>

--- a/crm_claim_number/crm_claim_view.xml
+++ b/crm_claim_number/crm_claim_view.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+<!-- CLAIM VIEWS -->
+        <record model="ir.ui.view" id="crm_case_claims_tree_view">
+            <field name="name">CRM - Claims Tree</field>
+            <field name="model">crm.claim</field>
+            <field name="inherit_id" ref="crm_claim.crm_case_claims_tree_view"/>
+            <field name="arch" type="xml">
+                <field name="name" position="before">
+                    <field name="number" />
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="crm_case_claims_form_view">
+            <field name="name">CRM - Claim Form</field>
+            <field name="model">crm.claim</field>
+            <field name="inherit_id" ref="crm_claim.crm_case_claims_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//sheet/group" position="before">
+                    <div class="oe_title">
+                        <label for="number" class="oe_edit_only"/>
+                        <h1><field name="number"/></h1>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+
+<!-- Crm claim Search view -->
+        <record id="view_crm_case_claims_filter" model="ir.ui.view">
+            <field name="name">CRM - Claims Search</field>
+            <field name="model">crm.claim</field>
+            <field name="inherit_id" ref="crm_claim.view_crm_case_claims_filter"/>
+            <field name="arch" type="xml">
+                <field name="name" string="Claims" position="before">
+                    <field name="number"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Was looking at porting CRM Claim RMA, but realized that I am not familiar enough with it to reliably port all of it to how the new pickings work. Seeing that the only thing we actually need at the moment was the number field that does not have anything to do with RMAs, I can at least make that available in 8 easily.
