### PR TITLE
[IMP] crm_claim_rma module adapted to new features with respect to picking in Odoo 8.0

### DIFF
--- a/crm_claim_rma/__openerp__.py
+++ b/crm_claim_rma/__openerp__.py
@@ -81,6 +81,7 @@ Contributors:
         'stock',
         'crm_claim',
         'crm_claim_code',
+        'crm_claim_type',
         'product_warranty',
     ],
     'data': [

--- a/crm_claim_rma/test/test_invoice_refund.yml
+++ b/crm_claim_rma/test/test_invoice_refund.yml
@@ -22,7 +22,7 @@
 -
   !record {model: crm.claim, id: claim_refund}:
     name: 'Angry Customer'
-    claim_type: customer
+    claim_type: crm_claim_type.crm_claim_type_customer
     partner_id: base.res_partner_3
     invoice_id: account_invoice_claim_refund
     stage_id: crm_claim.stage_claim1
@@ -54,3 +54,4 @@
     refund_lines = self.pool.get('account.invoice.line').browse(cr, uid, refund_line_ids)
     assert ref('product.product_product_4') in [refund_lines[0].product_id.id, refund_lines[1].product_id.id], "First line is checked"
     assert ref('product.product_product_5') in [refund_lines[0].product_id.id, refund_lines[1].product_id.id], "Second line is checked"
+

--- a/crm_claim_rma/tests/test_picking_creation.py
+++ b/crm_claim_rma/tests/test_picking_creation.py
@@ -2,6 +2,8 @@
 ##############################################################################
 #
 #    Author: Yannick Vaucher
+#            Yanina Aular
+#    Copyright 2015 Vauxoo
 #    Copyright 2014 Camptocamp SA
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -21,16 +23,15 @@
 from openerp.tests import common
 
 
-class test_picking_creation(common.TransactionCase):
+class TestPickingCreation(common.TransactionCase):
+
     """ Test the correct pickings are created by the wizard. """
 
     def setUp(self):
-        super(test_picking_creation, self).setUp()
+        super(TestPickingCreation, self).setUp()
 
-        self.WizardMakePicking = self.env['claim_make_picking.wizard']
-        self.StockPicking = self.env['stock.picking']
-        ClaimLine = self.env['claim.line']
-        Claim = self.env['crm.claim']
+        self.wizard_make_picking = self.env['claim_make_picking.wizard']
+        claim = self.env['crm.claim']
 
         self.product_id = self.env.ref('product.product_product_4')
 
@@ -39,41 +40,44 @@ class test_picking_creation(common.TransactionCase):
         self.customer_location_id = self.env.ref(
             'stock.stock_location_customers')
 
+        sale_order_agrolait_demo = self.env.ref('sale.sale_order_1')
+        self.assertTrue(sale_order_agrolait_demo.invoice_ids,
+                        "The Order Sale of Agrolait not have Invoice")
+        invoice_agrolait = sale_order_agrolait_demo.invoice_ids[0]
+        invoice_agrolait.\
+            signal_workflow('invoice_open')
+
         # Create the claim with a claim line
-        self.claim_id = Claim.create(
+        self.claim_id = claim.create(
             {
                 'name': 'TEST CLAIM',
-                'number': 'TEST CLAIM',
-                'claim_type': 'customer',
+                'code': '/',
+                'claim_type': self.env.ref('crm_claim_type.'
+                                           'crm_claim_type_customer').id,
                 'delivery_address_id': self.partner_id.id,
+                'partner_id': self.env.ref('base.res_partner_2').id,
+                'invoice_id': invoice_agrolait.id,
             })
-
+        self.claim_id.with_context({'create_lines': True}).\
+            _onchange_invoice_warehouse_type_date()
         self.warehouse_id = self.claim_id.warehouse_id
-        self.claim_line_id = ClaimLine.create(
-            {
-                'name': 'TEST CLAIM LINE',
-                'claim_origine': 'none',
-                'product_id': self.product_id.id,
-                'claim_id': self.claim_id.id,
-                'location_dest_id': self.warehouse_id.lot_stock_id.id,
-            })
 
     def test_00_new_product_return(self):
         """Test wizard creates a correct picking for product return
 
         """
-        wizard = self.WizardMakePicking.with_context({
+        wizard = self.wizard_make_picking.with_context({
             'active_id': self.claim_id.id,
             'partner_id': self.partner_id.id,
             'warehouse_id': self.warehouse_id.id,
             'picking_type': 'in',
+            'product_return': True,
         }).create({})
         wizard.action_create_picking()
 
         self.assertEquals(len(self.claim_id.picking_ids), 1,
                           "Incorrect number of pickings created")
         picking = self.claim_id.picking_ids[0]
-
         self.assertEquals(picking.location_id, self.customer_location_id,
                           "Incorrect source location")
         self.assertEquals(picking.location_dest_id,
@@ -85,8 +89,8 @@ class test_picking_creation(common.TransactionCase):
 
         """
 
-        WizardChangeProductQty = self.env['stock.change.product.qty']
-        wizard_chg_qty = WizardChangeProductQty.with_context({
+        wizardchangeproductqty = self.env['stock.change.product.qty']
+        wizard_chg_qty = wizardchangeproductqty.with_context({
             'active_id': self.product_id.id,
         }).create({
             'product_id': self.product_id.id,
@@ -95,7 +99,7 @@ class test_picking_creation(common.TransactionCase):
 
         wizard_chg_qty.change_product_qty()
 
-        wizard = self.WizardMakePicking.with_context({
+        wizard = self.wizard_make_picking.with_context({
             'active_id': self.claim_id.id,
             'partner_id': self.partner_id.id,
             'warehouse_id': self.warehouse_id.id,
@@ -110,4 +114,31 @@ class test_picking_creation(common.TransactionCase):
         self.assertEquals(picking.location_id, self.warehouse_id.lot_stock_id,
                           "Incorrect source location")
         self.assertEquals(picking.location_dest_id, self.customer_location_id,
+                          "Incorrect destination location")
+
+    def test_02_new_product_return(self):
+        """Test wizard creates a correct picking for product return
+
+        """
+        company = self.env.ref('base.main_company')
+        warehouse_obj = self.env['stock.warehouse']
+        warehouse_rec = \
+            warehouse_obj.search([('company_id',
+                                   '=', company.id)])[0]
+        wizard = self.wizard_make_picking.with_context({
+            'active_id': self.claim_id.id,
+            'partner_id': self.partner_id.id,
+            'warehouse_id': self.warehouse_id.id,
+            'picking_type': warehouse_rec.in_type_id.id,
+        }).create({})
+        wizard.action_create_picking()
+
+        self.assertEquals(len(self.claim_id.picking_ids), 1,
+                          "Incorrect number of pickings created")
+        picking = self.claim_id.picking_ids[0]
+
+        self.assertEquals(picking.location_id, self.customer_location_id,
+                          "Incorrect source location")
+        self.assertEquals(picking.location_dest_id,
+                          self.warehouse_id.lot_stock_id,
                           "Incorrect destination location")

--- a/crm_claim_rma/views/crm_claim_rma.xml
+++ b/crm_claim_rma/views/crm_claim_rma.xml
@@ -60,9 +60,9 @@
                     <field name="product_id"/>
                     <field name="name"/>
                     <field name="prodlot_id"/>
-                    <field name="warning"/> 
-                    <field name="warranty_type"/> 
-                    <field name="warranty_return_partner"/> 
+                    <field name="warning"/>
+                    <field name="warranty_type"/>
+                    <field name="warranty_return_partner"/>
                     <button name="set_warranty" string="Compute Waranty" type="object" icon="gtk-justify-fill"/>
                     <field name="product_returned_quantity"/>
                     <field name="claim_origine"/>
@@ -260,8 +260,19 @@
             action="act_crm_claim_substates"
             sequence="2"/>
 
+        <record model="ir.ui.view" id="crm_case_claims_form_view">
+            <field name="name">CRM - Claims Form</field>
+            <field name="model">crm.claim</field>
+            <field name="inherit_id" ref="crm_claim_type.crm_case_claims_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='claim_type']" position="attributes">
+                    <attribute name="context">{'create_lines': False}</attribute>
+                </xpath>
+            </field>
+        </record>
+
         <record model="ir.ui.view" id="crm_claim_rma_form_view">
-            <field name="name">CRM - Claim product return Form</field>
+            <field name="name">CRM - Claims Form</field>
             <field name="model">crm.claim</field>
             <field name="inherit_id" ref="crm_claim.crm_case_claims_form_view"/>
             <field name="arch" type="xml">
@@ -286,7 +297,6 @@
                         context="{'invoice_ids': [invoice_id], 'claim_line_ids': claim_line_ids, 'description': name, 'claim_id': id}"/>
                 </field>
                 <field name="date_deadline" position="after">
-                    <field name="claim_type" context="{'create_lines': False}"/>
                     <field name="warehouse_id" context="{'create_lines': False}"/>
                 </field>
                 <field name="date" position="replace"/>
@@ -300,49 +310,56 @@
                                 string="Quotation/Sales"
                                 icon="fa-strikethrough"
                                 class="oe_stat_button"
-                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['supplier','other'])]}"
+                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in',
+                                [%(crm_claim_type.crm_claim_type_supplier)d,%(crm_claim_type.crm_claim_type_other)d])]}"
                                 context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"/>
 
                         <button name="%(act_crm_claim_rma_invoice_out)d" type="action"
                                 string="Invoices"
                                 icon="fa-pencil-square-o"
                                 class="oe_stat_button"
-                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['supplier','other'])]}"
+                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in',
+                                [%(crm_claim_type.crm_claim_type_supplier)d,%(crm_claim_type.crm_claim_type_other)d])]}"
                                 context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"/>
 
                         <button name="%(act_crm_claim_rma_refunds_out)d" type="action"
                                 string="Refunds"
                                 icon="fa-file-text-o"
                                 class="oe_stat_button"
-                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['supplier','other'])]}"
+                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in',
+                                [%(crm_claim_type.crm_claim_type_supplier)d,%(crm_claim_type.crm_claim_type_other)d])]}"
                                 context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"/>
 
                         <button name="%(act_crm_claim_rma_invoice_in)d" type="action"
                                 string="Invoices"
                                 icon="fa-pencil-square-o"
                                 class="oe_stat_button"
-                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['customer','other'])]}"
+                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in',
+                                [%(crm_claim_type.crm_claim_type_customer)d,%(crm_claim_type.crm_claim_type_other)d])]}"
                                 context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"/>
 
                         <button name="%(act_crm_claim_rma_refunds_in)d" type="action"
                                 string="Refunds"
                                 icon="fa-file-text-o"
                                 class="oe_stat_button"
-                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['customer','other'])]}"
+                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in',
+                                [%(crm_claim_type.crm_claim_type_customer)d,%(crm_claim_type.crm_claim_type_other)d])]}"
                                 context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"/>
 
                         <button name="%(act_crm_claim_rma_picking_in)d" type="action"
                                 string="Products"
                                 icon="fa-reply"
                                 class="oe_stat_button"
-                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['supplier','other'])]}"
+                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in',
+                                [%(crm_claim_type.crm_claim_type_customer)d,%(crm_claim_type.crm_claim_type_other)d])]}"
                                 context="{'search_default_claim_id': active_id,'search_default_user_id':False}"/>
 
                         <button name="%(act_crm_claim_rma_picking_out)d" type="action"
                                 string="Deliveries"
                                 icon="fa-truck"
                                 class="oe_stat_button"
-                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in', ['supplier','other'])]}"
+                                attrs="{'invisible': ['|',('partner_id','=', False),('claim_type','in',
+                                [%(crm_claim_type.crm_claim_type_supplier)d,%(crm_claim_type.crm_claim_type_other)d])]}"
                                 context="{'search_default_partner_id': [partner_id],'search_default_user_id':False}"/>
                     </div>
                 </xpath>
@@ -369,9 +386,9 @@
                                 <field name="invoice_id" domain="['|',('commercial_partner_id','=',partner_id),('partner_id','=',partner_id)]" context="{'create_lines': True}"/>
                                 <field name="delivery_address_id" context="{'tree_view_ref': 'crm_claim_rma.view_partner_contact_tree', 'search_default_parent_id': partner_id}"/>
                             </group>
-                            <group>
+                            <div name="serial">
                                 <!-- Place for mass return button from crm_rma_lot_mass_return -->
-                            </group>
+                            </div>
                             <field
                                 name="claim_line_ids"
                                 nolabel="1"

--- a/crm_claim_rma/wizards/claim_make_picking.xml
+++ b/crm_claim_rma/wizards/claim_make_picking.xml
@@ -25,11 +25,12 @@
                             name="action_create_picking" type="object"
                             class="oe_highlight"/>
                         or
-                        <button string="Cancel" class="oe_link" special="cancel"/>
+                        <button name="action_cancel"
+                            string="Cancel" class="oe_link" special="cancel" />
                     </footer>
                 </form>
             </field>
-        </record> 
+        </record>
 
         <record id="action_claim_picking_in" model="ir.actions.act_window">
             <field name="name">Return Products</field>
@@ -38,7 +39,7 @@
             <field name="src_model">crm.claim</field>
             <field name="view_type">form</field>
             <field name="view_mode">form</field>
-            <field name="target">new</field> 
+            <field name="target">new</field>
             <field name="context">{'picking_type': 'in','product_return': True}</field>
         </record>
 
@@ -49,7 +50,7 @@
             <field name="src_model">crm.claim</field>
             <field name="view_type">form</field>
             <field name="view_mode">form</field>
-            <field name="target">new</field> 
+            <field name="target">new</field>
             <field name="context">{'picking_type': 'out'}</field>
         </record>
 


### PR DESCRIPTION
## Enhancements and fixes:
- crm_claim_rma module adapted to new characteristics with respect to picking in stock module. 
  Now, create pickings in rma is working with odoo 8.0. http://youtu.be/wG-UFXpCoCA
- crm_claim_rma module updated to crm_claim_type module of the OCA/crm
- <a href="runbot.odoo-community.org/runbot/build/3114474">Error on runbot</a> is corrected =>  <b>_auto_init Table `crm_claim`: column `claim_type` has changed type (DB=int4, def=selection), data moved to column `claim_type_moved0`</b> The definition of claim_type field is repeated.
- New tests is added with demo invoice and and subsequently make claim lines from the invoice lines
- wf_service.trg_validate changed by signal_workflow (new way to activate signals in odoo 8.0)
- Add claim lines is corrected, <a href="https://github.com/OCA/rma/pull/47/files#diff-2e2d61b52eae4e2807850aa7f95aaa61L503">the cycle is changed by list of tuples</a> because on the tests only is added the last invoice line and the correct way is like <a href="https://github.com/odoo/odoo/blob/8.0/openerp/osv/fields.py#L1591">said here</a>

```
-                claim_lines.append([0, 0, line])
+                claim_lines.append((0, 0, line))

-        for line in claim_lines:
-            value = self._convert_to_cache(
-                {'claim_line_ids': line}, validate=False)
-            self.update(value)
+        value = self._convert_to_cache(
+            {'claim_line_ids': claim_lines}, validate=False)
+        self.update(value)
```
