### PR TITLE
Fix authors list in manifest file

### DIFF
--- a/crm_claim_rma/__openerp__.py
+++ b/crm_claim_rma/__openerp__.py
@@ -71,7 +71,7 @@ Contributors:
  * Javier Carrasco <javier.carrasco@eezee-it.com>
 
 """,
-    'author': "Akretion, Camptocamp, Eezee-it, MONK Software"
+    'author': "Akretion, Camptocamp, Eezee-it, MONK Software, "
               "Odoo Community Association (OCA)",
     'website': 'http://www.akretion.com, http://www.camptocamp.com, '
                'http://www.eezee-it.com, http://www.wearemonk.com',


### PR DESCRIPTION
Missing comma/whitespace causes MONK Software and OCA to be a single entity on apps.odoo.com
