### PR TITLE
[FIX]crm_claim_rma: Removed stock.pciking create function.

### DIFF
--- a/crm_claim_rma/__openerp__.py
+++ b/crm_claim_rma/__openerp__.py
@@ -24,7 +24,7 @@
 
 {
     'name': 'RMA Claim (Product Return Management)',
-    'version': '8.0.1.1.0',
+    'version': '8.0.1.1.1',
     'category': 'Generic Modules/CRM & SRM',
     'description': """
 Management of Return Merchandise Authorization (RMA)

--- a/crm_claim_rma/models/stock.py
+++ b/crm_claim_rma/models/stock.py
@@ -30,13 +30,6 @@ class StockPicking(models.Model):
 
     claim_id = fields.Many2one('crm.claim', string='Claim')
 
-    @api.model
-    @api.returns('self', lambda value: value.id)
-    def create(self, vals):
-        if ('name' not in vals) or (vals.get('name') == '/'):
-            vals['name'] = self.env['ir.sequence'].get(self._name)
-        return super(StockPicking, self).create(vals)
-
 
 class StockMove(models.Model):
     _inherit = "stock.move"


### PR DESCRIPTION
The inheritance of stock.picking create has no sense in v8.0, always returns an incorrect name.

Example:
INT/001 (without warehouse) instead of WH01/OUT/001
