### PR TITLE
[FIX] add oca_dependencies, remove git clone from travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,6 @@ install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git $HOME/maintainer-quality-tools
   - export PATH=$HOME/maintainer-quality-tools/travis:$PATH
   - travis_install_nightly
-  # add OCA/crm dependencies
-  - git clone --depth=1 https://github.com/OCA/crm -b ${VERSION} $HOME/crm
-  - git clone --depth=1 https://github.com/OCA/stock-logistics-workflow -b ${VERSION} $HOME/stock-logistics-workflow
 
 script:
   - travis_run_tests

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,2 @@
+stock-logistics-workflow
+crm


### PR DESCRIPTION
This PR adds `oca_dependencies.txt` file and remove git clone's from travis
