### PR TITLE
[FIX] crm_claim_rma: Fixed company_id default fields

### DIFF
--- a/crm_claim_rma/models/claim_line.py
+++ b/crm_claim_rma/models/claim_line.py
@@ -44,6 +44,13 @@ class ClaimLine(models.Model):
     _description = "List of product to return"
     _rec_name = "display_name"
 
+    @api.model
+    def _get_company_default(self):
+        company_env = self.env['res.company']
+        default_company_id = company_env._company_default_get(
+            'claim.line')
+        return company_env.browse(default_company_id)
+
     SUBJECT_LIST = [('none', 'Not specified'),
                     ('legal', 'Legal retractation'),
                     ('cancellation', 'Order cancellation'),
@@ -71,8 +78,7 @@ class ClaimLine(models.Model):
     company_id = fields.Many2one(
         'res.company', string='Company', readonly=False,
         change_default=True,
-        default=lambda self: self.env['res.company']._company_default_get(
-            'claim.line'))
+        default=_get_company_default)
     date = fields.Date('Claim Line Date',
                        select=True,
                        default=fields.date.today())

--- a/crm_claim_rma/models/crm_claim.py
+++ b/crm_claim_rma/models/crm_claim.py
@@ -40,6 +40,13 @@ class CrmClaim(models.Model):
                 _('There is no warehouse for the current user\'s company.'))
         return wh
 
+    @api.model
+    def _get_company_default(self):
+        company_env = self.env['res.company']
+        default_company_id = company_env._company_default_get(
+            'claim.line')
+        return company_env.browse(default_company_id)
+
     @api.multi
     def name_get(self):
         res = []
@@ -49,9 +56,7 @@ class CrmClaim(models.Model):
         return res
 
     company_id = fields.Many2one(change_default=True,
-                                 default=lambda self:
-                                 self.env['res.company']._company_default_get(
-                                     'crm.claim'))
+                                 default=_get_company_default)
 
     claim_line_ids = fields.One2many('claim.line', 'claim_id',
                                      string='Return lines')


### PR DESCRIPTION
Change company_id field default method to fix a problem  when upgrading this module from a previous version.

This is happening because in new api for Many2one fields is expecting an object and _company_default_get function is returning an id. So I've changed the default method of company_id field and converted it to a function so it can return a company object instead of an integer id.
