### PR TITLE
[FIX] Picking should be in state 'assigned' or 'partially_available' before transfer

### DIFF
--- a/crm_rma_lot_mass_return/demo/transfer_details.xml
+++ b/crm_rma_lot_mass_return/demo/transfer_details.xml
@@ -188,6 +188,9 @@
         </record>
 
         <!-- Make transfer of product -->
+        <function model="stock.picking" name="action_assign">
+            <value eval="obj(ref('so_wizard_rma_1')).picking_ids[0].id" model="sale.order"/>
+        </function>
 
         <function model="stock.transfer_details"
             name="do_detailed_transfer" eval="[ref('transfer_sale_wizard_rma')]"/>


### PR DESCRIPTION
According to change https://github.com/vauxoo-dev/odoo/commit/f89220a51313e1bf46ec82175f2449c2e1a0455c the picking state should be in 'assigned' or 'partially_available' before to transfer.
