### PR TITLE
Add product type filter when adding claim lines

### DIFF
--- a/crm_claim_rma/crm_claim_rma.py
+++ b/crm_claim_rma/crm_claim_rma.py
@@ -551,7 +551,8 @@ class crm_claim(orm.Model):
         warehouse_obj = self.pool['stock.warehouse']
         invoice_line_ids = invoice_line_obj.search(
             cr, uid,
-            [('invoice_id', '=', invoice_id)],
+            [('invoice_id', '=', invoice_id),
+             ('product_id.type', 'in', ('consu', 'product'))],
             context=context)
         claim_lines = []
         value = {}


### PR DESCRIPTION
When creating a new reception/delivery from the claim, claim lines with non-stockable products are not used: https://github.com/OCA/rma/blob/7.0/crm_claim_rma/wizard/claim_make_picking.py#L284 
However, when creating those claim lines in `onchange_invoice_id`, all invoice lines are used, including lines with non-stockable products.

Since a check is done afterwards in https://github.com/OCA/rma/blob/7.0/crm_claim_rma/wizard/claim_make_picking.py#L53 to ensure one and only one IN/OUT is created per claim line, this means that you can still create an IN/OUT for the non-stockable line, which will result in an empty picking.
