### PR TITLE
Add missing model decorator

### DIFF
--- a/crm_claim_rma/models/account_invoice.py
+++ b/crm_claim_rma/models/account_invoice.py
@@ -32,6 +32,7 @@ class AccountInvoice(models.Model):
 
     claim_id = fields.Many2one('crm.claim', string='Claim')
 
+    @api.model
     def _refund_cleanup_lines(self, lines):
         """
         Override when from claim to update the quantity and link to the


### PR DESCRIPTION
Breaks when module crm_claim_rma is installed and a "Modify/Cancel" refund is created.

PR fixes it.
