### PR TITLE
crm_claim_rma: use procurement for delivery

### DIFF
--- a/crm_claim_rma/models/__init__.py
+++ b/crm_claim_rma/models/__init__.py
@@ -28,6 +28,7 @@ from . import claim_line
 from . import crm_claim
 from . import invoice_no_date
 from . import product_no_supplier
+from . import procurement_group
 from . import stock_move
 from . import stock_picking
 from . import substate_substate

--- a/crm_claim_rma/models/procurement_group.py
+++ b/crm_claim_rma/models/procurement_group.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# © 2016 Cyril Gaudin (Camptocamp)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models
+
+
+class ProcurementGroup(models.Model):
+    _inherit = 'procurement.group'
+
+    claim_id = fields.Many2one('crm.claim', 'Claim')

--- a/crm_claim_rma/tests/test_picking_creation.py
+++ b/crm_claim_rma/tests/test_picking_creation.py
@@ -21,6 +21,7 @@
 #
 ##############################################################################
 from openerp.tests import common
+from openerp.tools.safe_eval import safe_eval
 
 
 class TestPickingCreation(common.TransactionCase):
@@ -86,9 +87,10 @@ class TestPickingCreation(common.TransactionCase):
                           "Incorrect destination location")
 
     def test_01_new_delivery(self):
-        """Test wizard creates a correct picking for a new delivery
-
+        """Test wizard creates and runs a procurement for a new delivery
         """
+
+        group_model = self.env['procurement.group']
 
         wizardchangeproductqty = self.env['stock.change.product.qty']
         wizard_chg_qty = wizardchangeproductqty.with_context({
@@ -100,6 +102,9 @@ class TestPickingCreation(common.TransactionCase):
 
         wizard_chg_qty.change_product_qty()
 
+        self.assertEqual(0, group_model.search_count([
+            ('claim_id', '=', self.claim_id.id)
+        ]))
         wizard = self.wizard_make_picking.with_context({
             'active_id': self.claim_id.id,
             'partner_id': self.partner_id.id,
@@ -108,29 +113,37 @@ class TestPickingCreation(common.TransactionCase):
         }).create({})
         wizard.action_create_picking()
 
+        procurement_group = group_model.search([
+            ('claim_id', '=', self.claim_id.id)
+        ])
+        self.assertEqual(1, len(procurement_group))
+
         self.assertEquals(len(self.claim_id.picking_ids), 1,
                           "Incorrect number of pickings created")
-        picking = self.claim_id.picking_ids[0]
 
-        self.assertEquals(picking.location_id, self.warehouse_id.lot_stock_id,
+        # Should have 1 procurement by product:
+        # One on Customer location and one on output
+        self.assertEqual(3, len(procurement_group.procurement_ids))
+
+        # And 2 pickings
+        self.assertEqual(1, len(self.claim_id.picking_ids))
+
+        self.assertEquals(self.warehouse_id.lot_stock_id,
+                          self.claim_id.picking_ids.location_id,
                           "Incorrect source location")
-        self.assertEquals(picking.location_dest_id, self.customer_location_id,
+        self.assertEquals(self.customer_location_id,
+                          self.claim_id.picking_ids.location_dest_id,
                           "Incorrect destination location")
 
     def test_02_new_product_return(self):
         """Test wizard creates a correct picking for product return
 
         """
-        company = self.env.ref('base.main_company')
-        warehouse_obj = self.env['stock.warehouse']
-        warehouse_rec = \
-            warehouse_obj.search([('company_id',
-                                   '=', company.id)])[0]
         wizard = self.wizard_make_picking.with_context({
             'active_id': self.claim_id.id,
             'partner_id': self.partner_id.id,
             'warehouse_id': self.warehouse_id.id,
-            'picking_type': warehouse_rec.in_type_id.id,
+            'picking_type': 'in',
         }).create({})
         wizard.action_create_picking()
 
@@ -143,23 +156,6 @@ class TestPickingCreation(common.TransactionCase):
         self.assertEquals(picking.location_dest_id,
                           self.warehouse_id.lot_stock_id,
                           "Incorrect destination location")
-
-    def create_invoice(self):
-        sale_order_id = self.env['sale.order'].create({
-            'partner_id': self.ref('base.res_partner_9'),
-            'client_order_ref': 'TEST_SO',
-            'order_policy': 'manual',
-            'order_line': [(0, 0, {
-                'product_id': self.ref('product.product_product_8'),
-                'product_uom_qty': 2
-            })]
-        })
-        sale_order_id.action_button_confirm()
-        sale_order_id.action_invoice_create()
-        self.assertTrue(sale_order_id.invoice_ids)
-        invoice_id = sale_order_id.invoice_ids
-        invoice_id.signal_workflow('invoice_open')
-        return invoice_id
 
     def test_03_invoice_refund(self):
         claim_id = self.env['crm.claim'].browse(
@@ -185,7 +181,7 @@ class TestPickingCreation(common.TransactionCase):
 
         self.assertTrue(res)
         self.assertEquals(res['res_model'], 'account.invoice')
-        self.assertEquals(eval(res['context'])['type'], 'out_refund')
+        self.assertEquals(safe_eval(res['context'])['type'], 'out_refund')
 
     def test_04_display_name(self):
         """

--- a/crm_claim_rma/wizards/claim_make_picking.xml
+++ b/crm_claim_rma/wizards/claim_make_picking.xml
@@ -12,9 +12,10 @@
             <field name="name">claim_picking</field>
             <field name="model">claim_make_picking.wizard</field>
             <field name="arch" type="xml">
-                <form string="Select exchange lines to add in picking" version="7.0">
+                <form string="Select exchange lines to add in picking">
                     <group name="locations" string="Locations">
-                        <field name="claim_line_source_location_id"/>
+                        <field name="delivery_warehouse_id" invisible="context.get('picking_type') != 'out'" required="context.get('picking_type') == 'out'"/>
+                        <field name="claim_line_source_location_id" invisible="context.get('picking_type') == 'out'" required="context.get('picking_type') != 'out'"/>
                         <field name="claim_line_dest_location_id"/>
                     </group>
                     <separator string="Select lines for picking"/>

--- a/crm_rma_stock_location/tests/test_make_picking_from_picking.py
+++ b/crm_rma_stock_location/tests/test_make_picking_from_picking.py
@@ -71,7 +71,7 @@ class TestPickingFromPicking(TransactionCase):
             'active_id': self.claim_id.id,
             'warehouse_id': self.claim_id.warehouse_id.id,
             'partner_id': self.claim_id.partner_id.id,
-            'picking_type': self.claim_id.warehouse_id.rma_in_type_id.id,
+            'picking_type': 'in',
         }
         wizard_id = self.wizardmakepicking.with_context(wiz_context).create({})
 

--- a/crm_rma_stock_location/wizards/claim_make_picking.py
+++ b/crm_rma_stock_location/wizards/claim_make_picking.py
@@ -40,11 +40,6 @@ class ClaimMakePicking(models.TransientModel):
         claim_id = self.env.context.get('active_id')
         claim_record = self.env['crm.claim'].browse(claim_id)
 
-        if isinstance(picking_type, int):
-            picking_obj = self.env['stock.picking.type']
-            return picking_obj.browse(picking_type)\
-                .default_location_dest_id
-
         if picking_type == 'out':
             return claim_record.warehouse_id.rma_out_type_id.\
                 default_location_dest_id


### PR DESCRIPTION
Create a procurement.order instead of manually creating stock.picking for delivery in claim.

So delivery in claim can use the same flow that classic delivery (e.g. if warehouse uses advanced routes).
