### PR TITLE
crm_rma_lot_mass_return: Fix build

### DIFF
--- a/crm_rma_lot_mass_return/demo/transfer_details.xml
+++ b/crm_rma_lot_mass_return/demo/transfer_details.xml
@@ -187,10 +187,5 @@
             <field name="lot_id" ref="lot_purchase_wizard_rma_item_4"/>
         </record>
 
-        <!-- Make transfer of product -->
-
-        <function model="stock.transfer_details"
-            name="do_detailed_transfer" eval="[ref('transfer_sale_wizard_rma')]"/>
-
     </data>
 </openerp>

--- a/crm_rma_lot_mass_return/tests/test_crm_rma_lot_mass_return_2.py
+++ b/crm_rma_lot_mass_return/tests/test_crm_rma_lot_mass_return_2.py
@@ -32,6 +32,12 @@ class TestCrmRmaLotMassReturn2(TransactionCase):
 
     def setUp(self):
         super(TestCrmRmaLotMassReturn2, self).setUp()
+        demo_transfer = self.browse_ref(
+            "crm_rma_lot_mass_return.transfer_sale_wizard_rma"
+        )
+        demo_transfer.picking_id.force_assign()
+        demo_transfer.do_detailed_transfer()
+
         self.metasearch_wizard = self.env['returned.lines.from.serial.wizard']
         self.sale_order = self.env.ref('crm_rma_lot_mass_return.'
                                        'so_wizard_rma_1')


### PR DESCRIPTION
RMA 8.0 build is broken since https://github.com/odoo/odoo/commit/f89220a51313e1bf46ec82175f2449c2e1a0455c

Demo data try to call do_detailed_transfer on a non-assigned picking.

I removed this call and fixed tests. (force assigign the picking and call do_detailed_transfer in setup)
