### PR TITLE
[IMP] Backport of product_warranty module from 9.0 to 8.0

### DIFF
--- a/crm_claim_rma/models/claim_line.py
+++ b/crm_claim_rma/models/claim_line.py
@@ -139,9 +139,8 @@ class ClaimLine(models.Model):
 
     @api.model
     def get_warranty_return_partner(self):
-        return self.env['product.supplierinfo']._columns[
-             'warranty_return_partner'
-         ].selection
+        return self.env['product.supplierinfo'].\
+            _columns['warranty_return_partner'].selection
 
     warranty_type = fields.Selection(
         get_warranty_return_partner, readonly=True,

--- a/crm_claim_rma/models/claim_line.py
+++ b/crm_claim_rma/models/claim_line.py
@@ -139,7 +139,9 @@ class ClaimLine(models.Model):
 
     @api.model
     def get_warranty_return_partner(self):
-        return self.env['product.supplierinfo'].get_warranty_return_partner()
+        return self.env['product.supplierinfo']._columns[
+             'warranty_return_partner'
+         ].selection
 
     warranty_type = fields.Selection(
         get_warranty_return_partner, readonly=True,

--- a/crm_claim_rma/tests/test_picking_creation.py
+++ b/crm_claim_rma/tests/test_picking_creation.py
@@ -21,6 +21,7 @@
 #
 ##############################################################################
 from openerp.tests import common
+from openerp.tools.safe_eval import safe_eval as eval
 
 
 class TestPickingCreation(common.TransactionCase):

--- a/product_warranty/README.rst
+++ b/product_warranty/README.rst
@@ -32,6 +32,7 @@ Contributors
 * Joël Grand-Guillaume <joel.grandguillaume@gmail.com>
 * Ondřej Kuzník <ondrej.kuznik@credativ.co.uk>
 * Yanina Aular <yanina.aular@vauxoo.com>
+* Cyril Gaudin <cyril.gaudin@camptocamp.com>
 
 Maintainer
 ----------

--- a/product_warranty/__init__.py
+++ b/product_warranty/__init__.py
@@ -1,23 +1,6 @@
 # -*- coding: utf-8 -*-
-#########################################################################
-#                                                                       #
-#                                                                       #
-#########################################################################
-#                                                                       #
-# Copyright (C) 2009-2011  Akretion, Emmanuel Samyn						#
-#                                                                       #
-# This program is free software: you can redistribute it and/or modify  #
-# it under the terms of the GNU General Public License as published by  #
-# the Free Software Foundation, either version 3 of the License, or     #
-# (at your option) any later version.                                   #
-#                                                                       #
-# This program is distributed in the hope that it will be useful,       #
-# but WITHOUT ANY WARRANTY; without even the implied warranty of        #
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
-# GNU General Public License for more details.                          #
-#                                                                       #
-# You should have received a copy of the GNU General Public License     #
-# along with this program.  If not, see <http://www.gnu.org/licenses/>. #
-#########################################################################
+# © 2016 Cyril Gaudin (Camptocamp)
+# © 2009-2011  Akretion, Emmanuel Samyn
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models

--- a/product_warranty/__openerp__.py
+++ b/product_warranty/__openerp__.py
@@ -1,24 +1,8 @@
 # -*- coding: utf-8 -*-
-#########################################################################
-#                                                                       #
-#                                                                       #
-#########################################################################
-#                                                                       #
-# Copyright (C) 2009-2011  Akretion, Emmanuel Samyn                     #
-#                                                                       #
-# This program is free software: you can redistribute it and/or modify  #
-# it under the terms of the GNU General Public License as published by  #
-# the Free Software Foundation, either version 3 of the License, or     #
-# (at your option) any later version.                                   #
-#                                                                       #
-# This program is distributed in the hope that it will be useful,       #
-# but WITHOUT ANY WARRANTY; without even the implied warranty of        #
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
-# GNU General Public License for more details.                          #
-#                                                                       #
-# You should have received a copy of the GNU General Public License     #
-# along with this program.  If not, see <http://www.gnu.org/licenses/>. #
-#########################################################################
+# © 2016 Yanina Aular (Vauxoo)
+# © 2016 Cyril Gaudin (Camptocamp)
+# © 2009-2011  Akretion, Emmanuel Samyn
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'Product warranty',
@@ -39,6 +23,5 @@
     ],
     'test': [],
     'installable': True,
-    'active': False,
     'images': ['images/product_warranty.png'],
 }

--- a/product_warranty/demo/product_warranty.xml
+++ b/product_warranty/demo/product_warranty.xml
@@ -37,7 +37,7 @@ Select the product you want to return and the reason for the return. You will ne
             <field name="warranty_return_partner">supplier</field>
             <field name="warranty_duration">12</field>
             <field name="product_tmpl_id" ref="product.product_product_3_product_template"/>
-            <field name="name" ref="base.res_partner_5"/>
+            <field name="name" ref="base.res_partner_3"/>
             <field name="delay">5</field>
             <field name="min_qty">1</field>
         </record>

--- a/product_warranty/models/__init__.py
+++ b/product_warranty/models/__init__.py
@@ -1,24 +1,7 @@
 # -*- coding: utf-8 -*-
-#########################################################################
-#                                                                       #
-#                                                                       #
-#########################################################################
-#                                                                       #
-# Copyright (C) 2009-2011  Akretion, Emmanuel Samyn						#
-#                                                                       #
-# This program is free software: you can redistribute it and/or modify  #
-# it under the terms of the GNU General Public License as published by  #
-# the Free Software Foundation, either version 3 of the License, or     #
-# (at your option) any later version.                                   #
-#                                                                       #
-# This program is distributed in the hope that it will be useful,       #
-# but WITHOUT ANY WARRANTY; without even the implied warranty of        #
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
-# GNU General Public License for more details.                          #
-#                                                                       #
-# You should have received a copy of the GNU General Public License     #
-# along with this program.  If not, see <http://www.gnu.org/licenses/>. #
-#########################################################################
+# © 2016 Cyril Gaudin (Camptocamp)
+# © 2009-2011  Akretion, Emmanuel Samyn
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import return_instruction
 from . import product_supplierinfo

--- a/product_warranty/models/product_supplierinfo.py
+++ b/product_warranty/models/product_supplierinfo.py
@@ -1,25 +1,8 @@
 # -*- coding: utf-8 -*-
-# ########################################################################
-#                                                                        #
-#                                                                        #
-# ########################################################################
-#                                                                        #
-# Copyright 2015 Vauxoo
-# Copyright (C) 2009-2011  Akretion, Emmanuel Samyn, Benoît Guillot      #
-#                                                                        #
-# This program is free software: you can redistribute it and/or modify   #
-# it under the terms of the GNU General Public License as published by   #
-# the Free Software Foundation, either version 3 of the License, or      #
-# (at your option) any later version.                                    #
-#                                                                        #
-# This program is distributed in the hope that it will be useful,        #
-# but WITHOUT ANY WARRANTY; without even the implied warranty of         #
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          #
-# GNU General Public License for more details.                           #
-#                                                                        #
-# You should have received a copy of the GNU General Public License      #
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.  #
-##########################################################################
+# © 2016 Cyril Gaudin (Camptocamp)
+# © 2015 Vauxoo
+# © 2009-2011  Akretion, Emmanuel Samyn, Benoît Guillot
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import api, fields, models
 
@@ -29,50 +12,41 @@ class ProductSupplierInfo(models.Model):
     _inherit = "product.supplierinfo"
 
     @api.model
-    def get_warranty_return_partner(self):
-        result = [('company', 'Company'),
-                  ('supplier', 'Supplier'),
-                  ('other', 'Other'),
-                  ]
-        return result
-
-    @api.model
     def _get_default_instructions(self):
         """ Get selected lines to add to exchange """
         instruction_ids = self.env['return.instruction']\
             .search([('is_default', '=', True)], limit=1)
         return instruction_ids
 
-    @api.one
     @api.depends('warranty_return_partner')
     def _compute_warranty_return_address(self):
         """ Method to return the partner delivery address or if none, the
         default address
         """
-        return_partner = self.warranty_return_partner
-        partner_id = self.company_id.partner_id.id
-        if return_partner:
-            if return_partner == 'supplier':
-                partner_id = self.name.id
-            elif return_partner == 'company':
-                if self.company_id.crm_return_address_id:
-                    partner_id = self.company_id.\
-                        crm_return_address_id.id
-            elif return_partner == 'other':
-                if self.warranty_return_other_address:
-                    partner_id = self.\
-                        warranty_return_other_address.id
-        self.warranty_return_address = partner_id
+        for record in self:
+            return_partner = record.warranty_return_partner
+            partner_id = record.company_id.partner_id.id
+            if return_partner:
+                if return_partner == 'supplier':
+                    partner_id = record.name.id
+                elif return_partner == 'company':
+                    if record.company_id.crm_return_address_id:
+                        partner_id = record.company_id.crm_return_address_id.id
+                elif return_partner == 'other':
+                    if record.warranty_return_other_address:
+                        partner_id = record.warranty_return_other_address.id
+            record.warranty_return_address = partner_id
 
     warranty_duration = fields.Float(
         'Period',
         help="Warranty in month for this product/supplier relation. Only "
              "for company/supplier relation (purchase order) ; the  "
              "customer/company relation (sale order) always use the "
-             "product main warranty field")
+             "product main warranty field"
+    )
     warranty_return_partner = fields.Selection(
-        get_warranty_return_partner,
-        'Return type',
+        [('company', 'Company'), ('supplier', 'Supplier'), ('other', 'Other')],
+        string='Return type',
         required=True,
         default='company',
         help="Who is in charge of the warranty return treatment toward the"
@@ -81,22 +55,27 @@ class ProductSupplierInfo(models.Model):
                 "brand manufacturer. Doesn't necessarly mean that the "
                 "warranty to be applied is the one of the return partner "
                 "(ie: can be returned to the company and be under the "
-                "brand warranty")
+                "brand warranty)"
+    )
     return_instructions = fields.Many2one(
         'return.instruction',
         'Instructions',
         default=_get_default_instructions,
-        help="Instructions for product return")
+        help="Instructions for product return"
+    )
     active_supplier = fields.Boolean(
-        help="Is this supplier still active, only for information")
+        help="Is this supplier still active, only for information"
+    )
     warranty_return_address = fields.Many2one(
         'res.partner',
         compute='_compute_warranty_return_address',
         string="Return address",
         help="Where the goods should be returned  "
-             "(computed field based on other infos.)")
+             "(computed field based on other infos.)"
+    )
     warranty_return_other_address = fields.Many2one(
         'res.partner',
         string='Return address',
         help="Where the customer has to send back the product(s) "
-             "if warranty return is set to 'other'.")
+             "if warranty return is set to 'other'."
+    )

--- a/product_warranty/models/res_company.py
+++ b/product_warranty/models/res_company.py
@@ -1,26 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright 2015 Vauxoo
-#    Copyright 2013 Camptocamp
-#    Copyright 2009-2013 Akretion,
-#    Author: Emmanuel Samyn, Raphaël Valyi, Sébastien Beau,
-#            Joel Grand-Guillaume
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2016 Joel Grand-Guillaume, Cyril Gaudin (Camptocamp)
+# © 2009-2013 Akretion, Emmanuel Samyn, Raphaël Valyi, Sébastien Beau
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import fields, models
 

--- a/product_warranty/models/return_instruction.py
+++ b/product_warranty/models/return_instruction.py
@@ -1,25 +1,8 @@
 # -*- coding: utf-8 -*-
-# ########################################################################
-#                                                                        #
-#                                                                        #
-# ########################################################################
-#                                                                        #
-# Copyright 2015 Vauxoo
-# Copyright (C) 2009-2011  Akretion, Emmanuel Samyn, Benoît Guillot      #
-#                                                                        #
-# This program is free software: you can redistribute it and/or modify   #
-# it under the terms of the GNU General Public License as published by   #
-# the Free Software Foundation, either version 3 of the License, or      #
-# (at your option) any later version.                                    #
-#                                                                        #
-# This program is distributed in the hope that it will be useful,        #
-# but WITHOUT ANY WARRANTY; without even the implied warranty of         #
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          #
-# GNU General Public License for more details.                           #
-#                                                                        #
-# You should have received a copy of the GNU General Public License      #
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.  #
-##########################################################################
+# © 2016 Cyril Gaudin (Camptocamp)
+# © 2015 Vauxoo
+# © 2009-2011  Akretion, Emmanuel Samyn, Benoît Guillot
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import fields, models
 

--- a/product_warranty/tests/test_product_warranty.py
+++ b/product_warranty/tests/test_product_warranty.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Author: Yanina Aular
-#    Copyright 2015 Vauxoo
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2016 Cyril Gaudin (Camptocamp)
+# © 2015 Vauxoo, Yanina Aular
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp.tests.common import TransactionCase
 
@@ -38,16 +22,19 @@ class TestProductWarranty(TransactionCase):
         product_tmpl_id = self.env.ref('product.product_product_3')
 
         partner_id = self.env.ref('base.res_partner_4')
+        other_partner = self.env.ref('base.res_partner_12')
 
-        supplierinfo_data = dict(name=partner_id.id,
-                                 product_name='Test SupplierInfo for'
-                                 ' display Default Instruction',
-                                 min_qty=4,
-                                 delay=5,
-                                 warranty_return_partner='supplier',
-                                 product_tmpl_id=product_tmpl_id.id,)
-        self.supplierinfo_brw = \
-            self.supplierinfo.create(supplierinfo_data)
+        supplierinfo_data = dict(
+            name=partner_id.id,
+            product_name='Test SupplierInfo for display Default Instruction',
+            min_qty=4,
+            delay=5,
+            warranty_return_partner='supplier',
+            product_tmpl_id=product_tmpl_id.id,
+            warranty_return_other_address=other_partner.id,
+        )
+
+        self.supplierinfo_brw = self.supplierinfo.create(supplierinfo_data)
 
     def test_default_instruction(self):
         """
@@ -78,3 +65,10 @@ class TestProductWarranty(TransactionCase):
         self.assertEquals(self.supplierinfo_brw.warranty_return_address.id,
                           self.supplierinfo_brw.company_id.
                           crm_return_address_id.id)
+
+        self.supplierinfo_brw.write({'warranty_return_partner': 'other'})
+
+        self.assertEquals(
+            self.supplierinfo_brw.warranty_return_address.id,
+            self.supplierinfo_brw.warranty_return_other_address.id
+        )

--- a/product_warranty/views/product_warranty_view.xml
+++ b/product_warranty/views/product_warranty_view.xml
@@ -1,29 +1,7 @@
 <?xml version="1.0"?>
-<!--
-##############################################################################
-#
-#    Copyright (C) 2009-2011  Akretion, Emmanuel Samyn
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
--->
-
 <openerp>
     <data>
-<!-- return instructions -->
-       <!-- supplier info tree view -->
+       <!-- return instructions tree view -->
         <record model="ir.ui.view" id="product_return_instructions_tree_view">
             <field name="name">product.return.instructions.tree</field>
             <field name="model">return.instruction</field>
@@ -36,7 +14,7 @@
             </field>
         </record>
 
-        <!-- supplier info form view -->
+        <!-- return instructions form view -->
         <record model="ir.ui.view" id="product_return_instructions_form_view">
             <field name="name">product.return.instructions.form</field>
             <field name="model">return.instruction</field>
@@ -64,20 +42,20 @@
             groups="base.group_no_one"
             id="menu_product_return_instructions_action"
             parent="product.prod_config_main" sequence="3"/>
-<!-- supplier info -->
+
         <!-- supplier info tree view -->
         <record model="ir.ui.view" id="product_supplierinfo_warranty_tree_view">
             <field name="name">product.supplierinfo.warranty.tree</field>
             <field name="model">product.supplierinfo</field>
             <field name="inherit_id" ref="product.product_supplierinfo_tree_view" />
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='delay']" position="after">
+                <field name="min_qty" position="before">
                     <field name="warranty_duration"/>
                     <field name="warranty_return_partner"/>
                     <field name="warranty_return_address"/>
                     <field name="active_supplier"/>
                     <field name="return_instructions"/>
-                </xpath>
+                </field>
             </field>
         </record>
 
@@ -87,7 +65,7 @@
             <field name="model">product.supplierinfo</field>
             <field name="inherit_id" ref="product.product_supplierinfo_form_view" />
             <field name="arch" type="xml">
-                <field position="after" name="company_id"  groups="base.group_multi_company" widget="selection">
+                <xpath expr="//group[last()]" position="after">
                     <group string="Warranty informations" colspan="4">
                         <field name="active_supplier"/>
                         <field name="warranty_duration"/>
@@ -97,12 +75,14 @@
                                 <field name="warranty_return_partner"/>
                             </group>
                             <group>
-                                <field name="warranty_return_other_address" attrs="{'invisible':[('warranty_return_partner', '!=', 'other')], 'required':[('warranty_return_partner', '=', 'other')]}" class="oe_inline"/>
+                                <field name="warranty_return_other_address"
+                                       attrs="{'invisible':[('warranty_return_partner', '!=', 'other')], 'required':[('warranty_return_partner', '=', 'other')]}"
+                                       class="oe_inline"/>
                                 <field name="warranty_return_address" attrs="{'invisible':[('warranty_return_partner', '=', 'other')]}" class="oe_inline" />
                             </group>
                         </group>
                     </group>
-                </field>
+                </xpath>
             </field>
         </record>
 

--- a/product_warranty/views/res_company_view.xml
+++ b/product_warranty/views/res_company_view.xml
@@ -8,9 +8,11 @@
             <field name="model">res.company</field>
             <field name="inherit_id" ref="base.view_company_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='company_registry']" position="after">
+                <xpath expr="//field[@name='company_registry']/ancestor::group" position="after">
                     <separator string="Crm product return address"/>
-                    <field name="crm_return_address_id"/>
+                    <group>
+                        <field name="crm_return_address_id"/>
+                    </group>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
Backport of product_warranty module from 9.0 to 8.0 with two improvements in crm_claim_rma because the product warranty change and because pylint with eval was not correct
