### PR TITLE
Modify onchange in order to work for invoice_id

### DIFF
--- a/crm_claim_rma/views/crm_claim.xml
+++ b/crm_claim_rma/views/crm_claim.xml
@@ -278,14 +278,4 @@
             </xpath>
         </field>
     </record>
-    <record model="ir.ui.view" id="crm_case_claims_form_view">
-        <field name="name">CRM - Claims Form</field>
-        <field name="model">crm.claim</field>
-        <field name="inherit_id" ref="crm_claim_type.crm_case_claims_form_view"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='claim_type']" position="attributes">
-                <attribute name="context">{'create_lines': False}</attribute>
-            </xpath>
-        </field>
-    </record>
 </odoo>


### PR DESCRIPTION
Found an issue in the module `crm_claim_rma` : since the context from the view is not transferred to the onchange (it's for related fields only), the claim lines were not created when changing the invoice.

It's now fixed, and I added a comment on how this works.
