### PR TITLE
Change picking type to "Out"

### DIFF
--- a/crm_claim_rma/wizards/claim_make_picking.py
+++ b/crm_claim_rma/wizards/claim_make_picking.py
@@ -157,7 +157,7 @@ class ClaimMakePicking(models.TransientModel):
             picking_type = warehouse_rec.in_type_id
             write_field = 'move_in_id'
         else:
-            picking_type = warehouse_rec.int_type_id
+            picking_type = warehouse_rec.out_type_id
             write_field = 'move_out_id'
 
         partner_id = claim.delivery_address_id.id


### PR DESCRIPTION
Small issue (or maybe an explanation is needed?), but when creating an "OUT" picking with the method `_create_picking`, the picking type is set as an internal transfer, instead of a delivery.
