### PR TITLE
[FIX] crm_rma_prodlot_supplier: better inheritance

### DIFF
--- a/crm_rma_prodlot_supplier/models/stock_production_lot.py
+++ b/crm_rma_prodlot_supplier/models/stock_production_lot.py
@@ -46,6 +46,9 @@ class StockProductionLot(models.Model):
         res = super(StockProductionLot, self).default_get(fields_list)
 
         prodlot_obj = self.env['stock.production.lot']
+        if self._context.get('active_model') != 'stock.transfer_details_items':
+            return res
+
         transfer_item_id = self._context.get('active_id', False)
 
         if not transfer_item_id:


### PR DESCRIPTION
The rest of method does some stuff related to transfer details items.

If model is called from another model, e.g, a button or a function, etc. then, an nonexistent record error is raised, because transfer_item_id at line 51 is not related with the model from which is called. 
