### PR TITLE
[IMP] add hook to override field and picking type

### DIFF
--- a/crm_claim_rma/tests/test_picking_creation.py
+++ b/crm_claim_rma/tests/test_picking_creation.py
@@ -21,6 +21,7 @@
 #
 ##############################################################################
 from openerp.tests import common
+from openerp.tools import safe_eval
 
 
 class TestPickingCreation(common.TransactionCase):
@@ -185,7 +186,7 @@ class TestPickingCreation(common.TransactionCase):
 
         self.assertTrue(res)
         self.assertEquals(res['res_model'], 'account.invoice')
-        self.assertEquals(eval(res['context'])['type'], 'out_refund')
+        self.assertEquals(safe_eval(res['context'])['type'], 'out_refund')
 
     def test_04_display_name(self):
         """

--- a/crm_claim_rma/wizards/claim_make_picking.py
+++ b/crm_claim_rma/wizards/claim_make_picking.py
@@ -180,11 +180,10 @@ class ClaimMakePicking(models.TransientModel):
             'note': self._get_picking_note(),
         }
 
-    @api.multi
-    def action_create_picking(self):
-
-        context = self._context
-        picking_type = self.env.context.get('picking_type')
+    @api.model
+    def _get_picking_type_and_field(self):
+        context = self.env.context
+        picking_type = context.get('picking_type')
         if isinstance(picking_type, int):
             picking_obj = self.env['stock.picking.type']
             picking_type_rec = picking_obj.browse(picking_type)
@@ -206,7 +205,11 @@ class ClaimMakePicking(models.TransientModel):
         else:
             picking_type = warehouse_rec.int_type_id
             write_field = 'move_out_id'
+        return picking_type, write_field
 
+    @api.multi
+    def action_create_picking(self):
+        picking_type, write_field = self._get_picking_type_and_field()
         claim = self.env['crm.claim'].browse(self.env.context['active_id'])
         partner_id = claim.delivery_address_id.id
         claim_lines = self.claim_line_ids

--- a/crm_rma_claim_make_claim/tests/test_crm_rma_claim_make_claim.py
+++ b/crm_rma_claim_make_claim/tests/test_crm_rma_claim_make_claim.py
@@ -20,6 +20,7 @@
 ##############################################################################
 
 from openerp.tests.common import TransactionCase
+from openerp.tools.safe_eval import safe_eval
 
 
 class TestCrmRmaClaimMakeClaim(TransactionCase):
@@ -73,5 +74,5 @@ class TestCrmRmaClaimMakeClaim(TransactionCase):
     def test_01_claim_make_claim(self):
         claim_id = self.create_customer_claim()
         res = claim_id.claim_line_ids.button_create_line_rma_vendor()
-        lines_added = eval(res[0]['domain'])[0][2]
+        lines_added = safe_eval(res[0]['domain'])[0][2]
         self.assertEquals(len(claim_id.claim_line_ids), len(lines_added))

--- a/crm_rma_stock_location/tests/test_make_picking_from_picking.py
+++ b/crm_rma_stock_location/tests/test_make_picking_from_picking.py
@@ -20,6 +20,7 @@
 ##############################################################################
 
 from openerp.tests.common import TransactionCase
+from openerp.tools import safe_eval
 
 
 class TestPickingFromPicking(TransactionCase):
@@ -133,7 +134,7 @@ class TestPickingFromPicking(TransactionCase):
         }
         wizard_id = self.wizardmakepicking.with_context(new_context).create({})
 
-        default_location_dest_id = eval(
+        default_location_dest_id = safe_eval(
             'self.claim_id.warehouse_id.'
             'rma_%s_type_id.default_location_dest_id' % picking_type_str)
         self.assertEquals(
@@ -153,7 +154,8 @@ class TestPickingFromPicking(TransactionCase):
         }
         wizard_id = self.wizardmakepicking.with_context(new_context).create({})
 
-        default_location_dest_id = eval(
-            'self.claim_id.warehouse_id.loss_loc_id')
+        default_location_dest_id = safe_eval(
+            'self.claim_id.warehouse_id.loss_loc_id',
+            {'self': self})
         self.assertEquals(
             wizard_id.claim_line_dest_location_id, default_location_dest_id)


### PR DESCRIPTION
Hi

This PR adds a hook method to be able to override the written field in the wizard that creates a picking from the claim.
The PR that used this hook will come next (in the module crm_rma_stock_location)

Thanks for your reviews