### PR TITLE
[IMP] add field to link claim line to loss move

### DIFF
--- a/crm_rma_stock_location/__openerp__.py
+++ b/crm_rma_stock_location/__openerp__.py
@@ -44,6 +44,7 @@
         'wizards/claim_make_picking_view.xml',
         'views/product_product.xml',
         'views/product_template.xml',
+        'views/claim_line.xml',
         'views/crm_claim.xml',
         'views/stock_picking.xml',
         'views/stock_warehouse.xml',

--- a/crm_rma_stock_location/models/__init__.py
+++ b/crm_rma_stock_location/models/__init__.py
@@ -24,6 +24,7 @@
 #
 ##############################################################################
 
+from . import claim_line
 from . import product_product
 from . import product_template
 from . import stock_warehouse

--- a/crm_rma_stock_location/models/claim_line.py
+++ b/crm_rma_stock_location/models/claim_line.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Akretion (http://www.akretion.com).
+# @author Benoît GUILLOT <benoit.guillot@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import fields, models
+
+
+class ClaimLine(models.Model):
+    _inherit = 'claim.line'
+
+    move_loss_id = fields.Many2one(
+        'stock.move', string='Move Line from picking to loss location',
+        help='The move line related to the lost product')

--- a/crm_rma_stock_location/views/claim_line.xml
+++ b/crm_rma_stock_location/views/claim_line.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="crm_claim_line_tree_view">
+            <field name="name">CRM - Claims Tree</field>
+            <field name="model">claim.line</field>
+            <field name="inherit_id" ref="crm_claim_rma.crm_claim_line_tree_view"/>
+            <field name="arch" type="xml">
+                <field name="move_out_id" position="after">
+                    <field name="move_loss_id"/>
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="crm_claim_line_form_view">
+            <field name="name">CRM - Claim product return line Form</field>
+            <field name="model">claim.line</field>
+            <field name="inherit_id" ref="crm_claim_rma.crm_claim_line_form_view"/>
+            <field name="arch" type="xml">
+                <field name="move_out_id" position="after">
+                    <field name="move_loss_id"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/crm_rma_stock_location/wizards/claim_make_picking.py
+++ b/crm_rma_stock_location/wizards/claim_make_picking.py
@@ -21,7 +21,7 @@
 #
 ##############################################################################
 
-from openerp import models, fields
+from openerp import models, fields, api
 
 
 class ClaimMakePicking(models.TransientModel):
@@ -61,3 +61,11 @@ class ClaimMakePicking(models.TransientModel):
 
     claim_line_dest_location_id = fields.Many2one(
         default=_default_claim_line_dest_location_id)
+
+    @api.model
+    def _get_picking_type_and_field(self):
+        picking_type, write_field = super(
+            ClaimMakePicking, self)._get_picking_type_and_field()
+        if self.env.context.get('picking_type', '') == 'loss':
+            write_field = 'move_loss_id'
+        return picking_type, write_field


### PR DESCRIPTION
Hi,

This PR adds a new field on claim line to store the link of the move that goes to loss location.

Indeed for the moment if the movement is internal the field used to link the move to the claim line is the move_out_id.
That creates a problem when the customer never recieve the product so you want to put it in loss location and send a new product. If the field move_out_id is filled with the move to loss location, then you cannot create the out picking.

This PR needs the PR #124 

Thanks for the reviews