### PR TITLE
[10.0][IMP] Reworked _refund_cleanup_lines and test refund from claim

### DIFF
--- a/crm_claim_rma/tests/test_claim.py
+++ b/crm_claim_rma/tests/test_claim.py
@@ -30,3 +30,42 @@ class TestClaim(TransactionCase):
         self.assertEqual(supplier_type, claim.claim_type)
         self.assertIsNotNone(claim.code)
         self.assertTrue(claim.code.startswith('RMA-V/'))
+
+    def test_refund_from_claim(self):
+        invoice_ids = self.env.ref('sale.sale_order_4').action_invoice_create()
+        invoice = self.env['account.invoice'].browse(invoice_ids[0])
+        invoice.invoice_validate()
+        invoice_lines = invoice.mapped('invoice_line_ids')
+        default_tax = self.env['res.company']._company_default_get('account.tax')
+        invoice_lines.write(
+            {'invoice_line_tax_ids': [(4, default_tax.id, 0)]}
+        )
+        claim = self.env['crm.claim'].create({
+            'name': 'Test claim',
+            'invoice_id': invoice.id
+        })
+        claim._onchange_invoice()
+        claim.claim_line_ids[0].unlink()
+        refund_wizard = self.env['account.invoice.refund'].with_context({
+            'invoice_ids': [claim.invoice_id.id],
+            'claim_line_ids': [(4, line.id, 0) for line in claim.claim_line_ids],
+            'description': claim.name,
+            'claim_id': claim.id,
+        }).create({})
+        refund = refund_wizard.compute_refund()
+        refund_invoice = self.env['account.invoice'].search(refund['domain'])
+
+        self.assertTrue(refund_invoice)
+        self.assertEqual(
+            len(refund_invoice.invoice_line_ids),
+            len(claim.claim_line_ids)
+        )
+        self.assertEqual(
+            refund_invoice.invoice_line_ids.mapped('invoice_line_tax_ids'),
+            claim.claim_line_ids.mapped('invoice_line_id.invoice_line_tax_ids'),
+        )
+        self.assertEqual(
+            refund_invoice.invoice_line_ids.mapped('quantity'),
+            claim.claim_line_ids.mapped('product_returned_quantity'),
+        )
+        self.assertTrue(refund_invoice.tax_line_ids[0].tax_id.refund_account_id)


### PR DESCRIPTION
As discussed in #147 :

- _refund_cleanup_lines now uses sorted recordset to add claim values, there is no need
to C/P Odoo's code to acheive this
- _refund_cleanup_lines now returns empty list for account.invoice.tax calls to it,
this is needed because origin tax lines are sum-up of all taxes and in case of claim
not all invoice lines are refunded.
- field name fixed as discussed in issue.