### PR TITLE
[FIX] rma: portal views access errors

### DIFF
--- a/rma/README.rst
+++ b/rma/README.rst
@@ -89,8 +89,23 @@ An RMA can also be created from a return of a delivery order:
    Every RMA will be in confirmed state and they will
    be linked to the returning operation generated previously.
 
-**Note: An RMA can also be created from an incoming email (See configuration
-section).**
+There are Optional RMA Teams that can be used for:
+
+  - Organize RMAs in sections.
+  - Subscribe users to notifications.
+  - Create RMAs from incoming mail to special aliases (See configuration
+    section).
+
+To create an RMA Team (RMA Responsible user level required):
+
+  #. Go to *RMA > Configuration > RMA Teams*
+  #. Create a new team and assign a name, a responsible and members.
+  #. Subscribe users to notifications, that can be of these subtypes:
+
+     - RMA draft. When a new RMA is created.
+     - Notes, Debates, Activities. As in standard Odoo.
+  #. In the list view, use the cross handle to sort RMA Teams. The top team
+     will be the default one if no team is set.
 
 Known issues / Roadmap
 ======================

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -55,7 +55,6 @@ class Rma(models.Model):
         comodel_name="res.users",
         string="Responsible",
         track_visibility="always",
-        default=lambda self: self.env.user,
         states={
             'locked': [('readonly', True)],
             'cancelled': [('readonly', True)],
@@ -499,6 +498,9 @@ class Rma(models.Model):
                 ir_sequence = ir_sequence.with_context(
                     force_company=vals['company_id'])
             vals['name'] = ir_sequence.next_by_code('rma')
+        # Assign a default team_id which will be the first in the sequence
+        if "team_id" not in vals:
+            vals["team_id"] = self.env["rma.team"].search([], limit=1).id
         return super().create(vals)
 
     def copy(self, default=None):

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -599,7 +599,10 @@ class Rma(models.Model):
         """Invoked when 'Replace' button in rma form view is clicked."""
         self.ensure_one()
         self._ensure_can_be_replaced()
-        action = self.env.ref("rma.rma_delivery_wizard_action").read()[0]
+        # Force active_id to avoid issues when coming from smart buttons
+        # in other models
+        action = self.env.ref("rma.rma_delivery_wizard_action").with_context(
+            active_id=self.id).read()[0]
         action['name'] = 'Replace product(s)'
         action['context'] = dict(self.env.context)
         action['context'].update(
@@ -615,7 +618,10 @@ class Rma(models.Model):
         """
         self.ensure_one()
         self._ensure_can_be_returned()
-        action = self.env.ref("rma.rma_delivery_wizard_action").read()[0]
+        # Force active_id to avoid issues when coming from smart buttons
+        # in other models
+        action = self.env.ref("rma.rma_delivery_wizard_action").with_context(
+            active_id=self.id).read()[0]
         action['context'] = dict(self.env.context)
         action['context'].update(
             active_id=self.id,
@@ -628,9 +634,12 @@ class Rma(models.Model):
         """Invoked when 'Split' button in rma form view is clicked."""
         self.ensure_one()
         self._ensure_can_be_split()
-        action = self.env.ref("rma.rma_split_wizard_action").read()[0]
+        # Force active_id to avoid issues when coming from smart buttons
+        # in other models
+        action = self.env.ref("rma.rma_split_wizard_action").with_context(
+            active_id=self.id).read()[0]
         action['context'] = dict(self.env.context)
-        action['context'].update(active_ids=self.ids)
+        action['context'].update(active_id=self.id, active_ids=self.ids)
         return action
 
     def action_cancel(self):
@@ -663,7 +672,10 @@ class Rma(models.Model):
     def action_view_receipt(self):
         """Invoked when 'Receipt' smart button in rma form view is clicked."""
         self.ensure_one()
-        action = self.env.ref('stock.action_picking_tree_all').read()[0]
+        # Force active_id to avoid issues when coming from smart buttons
+        # in other models
+        action = self.env.ref('stock.action_picking_tree_all').with_context(
+            active_id=self.id).read()[0]
         action.update(
             res_id=self.reception_move_id.picking_id.id,
             view_mode="form",
@@ -687,7 +699,8 @@ class Rma(models.Model):
 
     def action_view_delivery(self):
         """Invoked when 'Delivery' smart button in rma form view is clicked."""
-        action = self.env.ref('stock.action_picking_tree_all').read()[0]
+        action = self.env.ref('stock.action_picking_tree_all').with_context(
+            active_id=self.id).read()[0]
         picking = self.delivery_move_ids.mapped('picking_id')
         if len(picking) > 1:
             action['domain'] = [('id', 'in', picking.ids)]

--- a/rma/models/rma_team.py
+++ b/rma/models/rma_team.py
@@ -8,8 +8,9 @@ class RmaTeam(models.Model):
     _name = "rma.team"
     _inherit = ['mail.alias.mixin', 'mail.thread']
     _description = "RMA Team"
-    _order = "name"
+    _order = "sequence, name"
 
+    sequence = fields.Integer()
     name = fields.Char(
         required=True,
         translate=True,

--- a/rma/readme/USAGE.rst
+++ b/rma/readme/USAGE.rst
@@ -33,5 +33,20 @@ An RMA can also be created from a return of a delivery order:
    Every RMA will be in confirmed state and they will
    be linked to the returning operation generated previously.
 
-**Note: An RMA can also be created from an incoming email (See configuration
-section).**
+There are Optional RMA Teams that can be used for:
+
+  - Organize RMAs in sections.
+  - Subscribe users to notifications.
+  - Create RMAs from incoming mail to special aliases (See configuration
+    section).
+
+To create an RMA Team (RMA Responsible user level required):
+
+  #. Go to *RMA > Configuration > RMA Teams*
+  #. Create a new team and assign a name, a responsible and members.
+  #. Subscribe users to notifications, that can be of these subtypes:
+
+     - RMA draft. When a new RMA is created.
+     - Notes, Debates, Activities. As in standard Odoo.
+  #. In the list view, use the cross handle to sort RMA Teams. The top team
+     will be the default one if no team is set.

--- a/rma/static/description/index.html
+++ b/rma/static/description/index.html
@@ -440,8 +440,29 @@ stock location and click on ‘Return’ button.</li>
 Every RMA will be in confirmed state and they will
 be linked to the returning operation generated previously.</li>
 </ol>
-<p><strong>Note: An RMA can also be created from an incoming email (See configuration
-section).</strong></p>
+<p>There are Optional RMA Teams that can be used for:</p>
+<blockquote>
+<ul class="simple">
+<li>Organize RMAs in sections.</li>
+<li>Subscribe users to notifications.</li>
+<li>Create RMAs from incoming mail to special aliases (See configuration
+section).</li>
+</ul>
+</blockquote>
+<p>To create an RMA Team (RMA Responsible user level required):</p>
+<blockquote>
+<ol class="arabic simple">
+<li>Go to <em>RMA &gt; Configuration &gt; RMA Teams</em></li>
+<li>Create a new team and assign a name, a responsible and members.</li>
+<li>Subscribe users to notifications, that can be of these subtypes:<ul>
+<li>RMA draft. When a new RMA is created.</li>
+<li>Notes, Debates, Activities. As in standard Odoo.</li>
+</ul>
+</li>
+<li>In the list view, use the cross handle to sort RMA Teams. The top team
+will be the default one if no team is set.</li>
+</ol>
+</blockquote>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#id3">Known issues / Roadmap</a></h1>

--- a/rma/views/rma_portal_templates.xml
+++ b/rma/views/rma_portal_templates.xml
@@ -50,7 +50,8 @@
                             </a>
                         </td>
                         <td class="d-none d-md-table-cell"><span t-field="rma.date"/></td>
-                        <td><span t-field="rma.product_id.name"/></td>
+                        <!-- Portal users don't have access to unpublished products -->
+                        <td><span t-esc="rma.sudo().product_id.display_name"/></td>
                         <td class='text-right'><span t-field="rma.product_uom_qty"/></td>
                         <td class="d-none d-md-table-cell tx_status">
                             <span class="badge badge-pill badge-secondary"><span t-field="rma.state"/></span>
@@ -132,12 +133,14 @@
                                         <span t-field="rma.picking_id"/>
                                     </div>
                                 </div>
-                                <div t-if="rma.product_id" class="row mb-2 mb-sm-1">
+                                <!-- We need to prevent access errors if the product is
+                                     unpublished-->
+                                <div t-if="rma.sudo().product_id" class="row mb-2 mb-sm-1">
                                     <div class="col-12 col-sm-4">
                                         <strong>Product</strong>
                                     </div>
                                     <div class="col-12 col-sm-8">
-                                        <span t-field="rma.product_id"/>
+                                        <span t-esc="rma.sudo().product_id.display_name"/>
                                     </div>
                                 </div>
                                 <div t-if="rma.product_uom_qty" class="row mb-2 mb-sm-1">
@@ -262,6 +265,9 @@
                 <h2>Communication</h2>
                 <t t-call="portal.message_thread">
                     <t t-set="object" t-value="rma"/>
+                    <t t-set="token" t-value="rma.access_token"/>
+                    <t t-set="pid" t-value="pid"/>
+                    <t t-set="hash" t-value="hash"/>
                 </t>
             </div>
         </t>

--- a/rma/views/rma_team_views.xml
+++ b/rma/views/rma_team_views.xml
@@ -2,6 +2,17 @@
 <!-- Copyright 2020 Tecnativa - Ernesto Tejeda
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
+    <record id="rma_team_view_tree" model="ir.ui.view">
+        <field name="model">rma.team</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="sequence" widget="handle" />
+                <field name="name" />
+                <field name="user_id" />
+                <field name="company_id" groups="base.group_multi_company" />
+            </tree>
+        </field>
+    </record>
     <record id="rma_team_view_form" model="ir.ui.view">
         <field name="name">rma.team.view.form</field>
         <field name="model">rma.team</field>

--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -29,9 +29,6 @@ class SaleOrderRmaWizard(models.TransientModel):
         default=lambda r: r.order_id.warehouse_id.rma_loc_id.id,
     )
 
-    def create_rma_from_portal(self):
-        self.ensure_one()
-
     def create_rma(self, from_portal=None):
         self.ensure_one()
         lines = self.line_ids.filtered(lambda r: r.quantity > 0.0)


### PR DESCRIPTION
- Portal mail thread needs token config.
- Unpublished products will raise AccessError on RMAs portal views for
portal users due to record rules.
- Set split window action domain to avoid context weird behavior

cc @Tecnativa TT24986