### PR TITLE
[IMP] rma_sale: portal improvents

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -503,6 +503,7 @@ class Rma(models.Model):
             vals["team_id"] = self.env["rma.team"].search([], limit=1).id
         return super().create(vals)
 
+    @api.multi
     def copy(self, default=None):
         team = super().copy(default)
         for follower in self.message_follower_ids:

--- a/rma/models/rma_team.py
+++ b/rma/models/rma_team.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Tecnativa - Ernesto Tejeda
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 
 
 class RmaTeam(models.Model):
@@ -37,7 +37,9 @@ class RmaTeam(models.Model):
         string='Team Members',
     )
 
+    @api.multi
     def copy(self, default=None):
+        self.ensure_one()
         if default is None:
             default = {}
         if not default.get('name'):

--- a/rma/models/stock_picking.py
+++ b/rma/models/stock_picking.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Tecnativa - Ernesto Tejeda
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockPicking(models.Model):
@@ -16,7 +16,9 @@ class StockPicking(models.Model):
         for rec in self:
             rec.rma_count = len(rec.move_lines.mapped('rma_ids'))
 
+    @api.multi
     def copy(self, default=None):
+        self.ensure_one()
         if self.env.context.get('set_rma_picking_type'):
             location_dest_id = default['location_dest_id']
             warehouse = self.env['stock.warehouse'].search(

--- a/rma/views/rma_views.xml
+++ b/rma/views/rma_views.xml
@@ -279,7 +279,7 @@
         </field>
     </record>
 
-    <record id="rma.rma_orders_menu" model="ir.ui.menu">
+    <record id="rma_orders_menu" model="ir.ui.menu">
         <field name="action" ref="rma_action"/>
     </record>
 </odoo>

--- a/rma_sale/README.rst
+++ b/rma_sale/README.rst
@@ -64,6 +64,15 @@ The customer can also create RMAs from a sales order portal page:
 #. Click on the 'Request RMAs' button and RMAs will be created linked to
    the sales order.
 
+Known issues / Roadmap
+======================
+
+* When you try to request an RMA from a Sales Order in the portal,
+  a popup appears and the inputs for the quantity doesn't allow
+  decimal numbers. It would be good to have a component that allows
+  that and at the same time keeps the constraint of not allowing a
+  number greater than the order line product quantity.
+
 Bug Tracker
 ===========
 

--- a/rma_sale/models/sale.py
+++ b/rma_sale/models/sale.py
@@ -74,15 +74,6 @@ class SaleOrder(models.Model):
             data += line.prepare_sale_rma_data()
         return data
 
-    def get_portal_delivery_rma_data(self):
-        self.ensure_one()
-        data = []
-        rma_product = self.rma_ids.mapped('product_id')
-        for line in self.order_line.filtered(
-                lambda r: r.product_id not in rma_product):
-            data += line.prepare_sale_rma_data()
-        return data
-
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"

--- a/rma_sale/readme/ROADMAP.rst
+++ b/rma_sale/readme/ROADMAP.rst
@@ -1,0 +1,5 @@
+* When you try to request an RMA from a Sales Order in the portal,
+  a popup appears and the inputs for the quantity doesn't allow
+  decimal numbers. It would be good to have a component that allows
+  that and at the same time keeps the constraint of not allowing a
+  number greater than the order line product quantity.

--- a/rma_sale/static/description/index.html
+++ b/rma_sale/static/description/index.html
@@ -376,11 +376,12 @@ order web portal page.</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -414,8 +415,18 @@ the quantity per product and delivery order line.</li>
 the sales order.</li>
 </ol>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>When you try to request an RMA from a Sales Order in the portal,
+a popup appears and the inputs for the quantity doesn’t allow
+decimal numbers. It would be good to have a component that allows
+that and at the same time keeps the constraint of not allowing a
+number greater than the order line product quantity.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/rma/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -423,15 +434,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
+<h1><a class="toc-backref" href="#id4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
+<h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Ernesto Tejeda</li>
@@ -442,7 +453,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/rma_sale/views/sale_portal_template.xml
+++ b/rma_sale/views/sale_portal_template.xml
@@ -17,13 +17,20 @@
                             <button type="button" class="close" data-dismiss="modal" aria-label="Close">&amp;times;</button>
                         </header>
                         <main class="modal-body" id="modal-body-request-rma">
-                            <div class="text-muted mb-2 mb-sm-1">
+                            <div class="alert alert-info mb-2 mb-sm-1" role="alert">
                                 <span>
-                                If an RMA has already been created for a product in this sales order, it will not
-                                be possible to create another one from the web portal.
+                                You're about to perform an RMA request. Our team will process it an will reach you once it's validated. Keep in mind that:
+                                <ul>
+                                    <li>Select the product quantity and the requested operation</li>
+                                    <li>Use the comment button to add relevant information regarding the RMA, like returned serial numbers or a description of the issue</li>
+                                    <li>If no requested operation is set, the RMA won't be correctly fulfilled</li>
+                                    <li>You can only return as much product units as you received for this order</li>
+                                    <li>The limit will decrease when the units in other RMAs are confirmed</li>
+                                    <li>You can send a message in every RMA sent</li>
+                                </ul>
                                 </span>
                             </div>
-                            <t t-set="data_list" t-value="sale_order.get_portal_delivery_rma_data()"/>
+                            <t t-set="data_list" t-value="sale_order.get_delivery_rma_data()"/>
                             <t t-set="operations" t-value="sale_order.env['rma.operation'].search([])"/>
                             <table class="table table-sm" id="request-rma-table">
                                 <thead class="bg-100">
@@ -32,6 +39,7 @@
                                         <th class="text-right">Quantity</th>
                                         <th class="text-left">Delivery</th>
                                         <th class="text-left">Requested operation</th>
+                                        <th name="portal_rma_button_desc" />
                                     </tr>
                                 </thead>
                                 <tbody class="request-rma-tbody">
@@ -46,12 +54,14 @@
                                                 </td>
                                                 <td class="text-right">
                                                     <div id="delivery-rma-qty">
-                                                        <input type="text"
+                                                        <input type="number"
                                                                t-attf-name="#{data_index}-quantity"
                                                                class="o_input text-right"
-                                                               placeholder="Quantity"
-                                                               t-att-value="data['quantity']"
-                                                               style="max-width: 100px;"/>
+                                                               placeholder="0"
+                                                               min="0"
+                                                               t-att-max="data['quantity']"
+                                                               t-att-value="0"
+                                                               style="max-width: 60px;"/>
                                                         <span t-esc="data['uom'].name" groups="uom.group_uom"/>
                                                         <input type="hidden"
                                                                t-attf-name="#{data_index}-uom_id"
@@ -74,6 +84,23 @@
                                                             </option>
                                                         </t>
                                                     </select>
+                                                </td>
+                                                <td>
+                                                    <button
+                                                        class="btn btn-primary fa fa-comments"
+                                                        type="button" data-toggle="collapse"
+                                                        t-attf-data-target="#comment-#{data_index}"
+                                                        aria-expanded="false"
+                                                        t-attf-aria-controls="comment-#{data_index}" />
+                                                </td>
+                                            </tr>
+                                            <tr class="collapse" t-attf-id="comment-#{data_index}">
+                                                <td colspan="5">
+                                                    <textarea
+                                                        class="form-control o_website_form_input"
+                                                        t-attf-name="#{data_index}-description"
+                                                        placeholder="Comment anything relevant to the return, like serial numbers, a description of the issue, etc"
+                                                    />
                                                 </td>
                                             </tr>
                                         </t>

--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -32,9 +32,6 @@ class SaleOrderRmaWizard(models.TransientModel):
     def create_rma(self, from_portal=None):
         self.ensure_one()
         lines = self.line_ids.filtered(lambda r: r.quantity > 0.0)
-        if from_portal:
-            rma_product = self.order_id.rma_ids.mapped('product_id')
-            lines = lines.filtered(lambda r: r.product_id not in rma_product)
         val_list = [line._prepare_rma_values() for line in lines]
         rma = self.env['rma'].create(val_list)
         # post messages
@@ -125,6 +122,7 @@ class SaleOrderLineRmaWizard(models.TransientModel):
         comodel_name='rma.operation',
         string='Requested operation',
     )
+    description = fields.Text()
 
     @api.onchange('product_id')
     def onchange_product_id(self):
@@ -166,4 +164,5 @@ class SaleOrderLineRmaWizard(models.TransientModel):
             'product_uom_qty': self.quantity,
             'product_uom': self.uom_id.id,
             'operation_id': self.operation_id.id,
+            'description': self.description,
         }


### PR DESCRIPTION
- Now it's possible to open several RMAs in a sale order from the portal
- A new comment button has been added to allow the portal user to enter
relevant information like serial numbers o issue description.
- If the requested operation isn't set no RMA will be opened
- The RMA product qty is now a numeric control with limits according to
the qty available to return

cc @Tecnativa TT24986