### PR TITLE
[12.0][FIX+IMP] rma: set rma to received on invoice delete.

### DIFF
--- a/rma/models/account_invoice.py
+++ b/rma/models/account_invoice.py
@@ -21,11 +21,12 @@ class AccountInvoice(models.Model):
             raise ValidationError(
                 _("There is at least one invoice lines whose quantity is "
                   "less than the quantity specified in its linked RMA."))
-        res = super().action_invoice_open()
-        self.sudo().mapped('invoice_line_ids.rma_id').write(
-            {'state': 'refunded'}
-        )
-        return res
+        return super().action_invoice_open()
+
+    def unlink(self):
+        rma = self.mapped('invoice_line_ids.rma_id')
+        rma.write({'state': 'received'})
+        return super().unlink()
 
 
 class AccountInvoiceLine(models.Model):

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -164,7 +164,6 @@ class Rma(models.Model):
             ("draft", "Draft"),
             ("confirmed", "Confirmed"),
             ("received", "Received"),
-            ("waiting_refund", "Waiting for refund"),
             ("waiting_return", "Waiting for return"),
             ("waiting_replacement", "Waiting for replacement"),
             ("refunded", "Refunded"),
@@ -402,7 +401,7 @@ class Rma(models.Model):
     def _compute_can_be_locked(self):
         for r in self:
             r.can_be_locked = (r.remaining_qty_to_done > 0
-                               and r.state in ['received', 'waiting_refund',
+                               and r.state in ['received',
                                                'waiting_return',
                                                'waiting_replacement'])
 
@@ -590,7 +589,7 @@ class Rma(models.Model):
                 rma.write({
                     'refund_line_id': line.id,
                     'refund_id': refund.id,
-                    'state': 'waiting_refund',
+                    'state': 'refunded',
                 })
             refund.message_post_with_view(
                 'mail.message_origin_link',

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -266,7 +266,7 @@ class TestRma(SavepointCase):
         self.assertEqual(rma.refund_line_id.product_id, rma.product_id)
         self.assertEqual(rma.refund_line_id.quantity, 10)
         self.assertEqual(rma.refund_line_id.uom_id, rma.product_uom)
-        self.assertEqual(rma.state, 'waiting_refund')
+        self.assertEqual(rma.state, 'refunded')
         self.assertFalse(rma.can_be_refunded)
         self.assertFalse(rma.can_be_returned)
         self.assertFalse(rma.can_be_replaced)
@@ -275,7 +275,6 @@ class TestRma(SavepointCase):
             rma.refund_id.action_invoice_open()
         rma.refund_line_id.quantity = 10
         rma.refund_id.action_invoice_open()
-        self.assertEqual(rma.state, 'refunded')
         self.assertFalse(rma.can_be_refunded)
         self.assertFalse(rma.can_be_returned)
         self.assertFalse(rma.can_be_replaced)
@@ -311,6 +310,8 @@ class TestRma(SavepointCase):
         ctx = dict(self.env.context)
         ctx.update(active_ids=all_rmas.ids, active_model='rma')
         action.with_context(ctx).run()
+        # After that all RMAs are in 'refunded' state
+        self.assertEqual(all_rmas.mapped('state'), ['refunded'] * 4)
         # Two refunds were created
         refund_1 = (rma_1 | rma_2 | rma_3).mapped('refund_id')
         refund_2 = rma_4.refund_id
@@ -351,7 +352,6 @@ class TestRma(SavepointCase):
         rma_2.refund_line_id.quantity = 15
         refund_1.action_invoice_open()
         refund_2.action_invoice_open()
-        self.assertEqual(all_rmas.mapped('state'), ['refunded']*4)
 
     def test_replace(self):
         # Create, confirm and receive an RMA
@@ -636,3 +636,15 @@ class TestRma(SavepointCase):
         self.assertEqual(new_rma.product_uom_qty + rma.product_uom_qty, 10)
         self.assertEqual(new_rma.move_id.quantity_done, 10)
         self.assertEqual(new_rma.reception_move_id.quantity_done, 10)
+
+    def test_rma_to_receive_on_delete_invoice(self):
+        rma = self._create_confirm_receive(self.partner, self.product, 10,
+                                           self.rma_loc)
+        rma.action_refund()
+        self.assertEqual(rma.state, 'refunded')
+        rma.refund_id.unlink()
+        self.assertFalse(rma.refund_id)
+        self.assertEqual(rma.state, 'received')
+        self.assertTrue(rma.can_be_refunded)
+        self.assertTrue(rma.can_be_returned)
+        self.assertTrue(rma.can_be_replaced)


### PR DESCRIPTION
Remove 'waiting_refund' rma state.
RMAs go from received state to refunded state.
When the linked refund is deleted the rma is set to received state.

cc @Tecnativa TT25519