### PR TITLE
[FIX+IMP] rma: usability

### DIFF
--- a/rma/migrations/12.0.2.0.0/post-migration.py
+++ b/rma/migrations/12.0.2.0.0/post-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2020 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Convert Text description field to Html
+    openupgrade.convert_field_to_html(
+        env.cr, "rma", "description", "description")

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -176,7 +176,7 @@ class Rma(models.Model):
         copy=False,
         track_visibility="onchange",
     )
-    description = fields.Text(
+    description = fields.Html(
         states={
             'locked': [('readonly', True)],
             'cancelled': [('readonly', True)],

--- a/rma/views/report_rma.xml
+++ b/rma/views/report_rma.xml
@@ -81,7 +81,7 @@
                 </div>
                 <div t-if="doc.description">
                     <strong>RMA Note:</strong>
-                    <p t-field="doc.description" />
+                    <p t-raw="doc.description" />
                 </div>
             </div>
         </t>

--- a/rma/views/rma_portal_templates.xml
+++ b/rma/views/rma_portal_templates.xml
@@ -256,7 +256,7 @@
                     <section id="description" class="mt-5" t-if="rma.description">
                         <h3 class="">Description</h3>
                         <hr class="mt-0 mb-1"/>
-                        <em t-field="rma.description"/>
+                        <t t-raw="rma.description"/>
                     </section>
                 </t>
             </t>

--- a/rma/views/rma_views.xml
+++ b/rma/views/rma_views.xml
@@ -19,6 +19,17 @@
                         string="Received"
                         domain="[('state','=', 'received')]" />
                 <separator />
+                <filter string="Unresolved RMAs"
+                        name="undone_rma"
+                        domain="[('state', 'not in', ['refunded', 'returned', 'replaced', 'locked', 'cancelled'])]"
+                        help="RMAs yet to be fully processed"/>
+                <filter string="Late RMAs"
+                        name="late_rma"
+                        domain="[('deadline', '&lt;', context_today().strftime('%Y-%m-%d')), ('state', 'not in', ['refunded', 'returned', 'replaced', 'locked', 'cancelled'])]"
+                        help="RMAs which deadline has passed"/>
+                <separator />
+                <filter string="RMA Date" name="filter_rma_date" date="date"/>
+                <filter string="RMA Deadline" name="filter_rma_deadline" date="deadline"/>
                 <filter name="no_user_id_filter"
                         string="Unassigned RMAs"
                         domain="[('user_id','=', False)]" />
@@ -48,7 +59,8 @@
         <field name="model">rma</field>
         <field name="arch" type="xml">
             <tree decoration-muted="state in ['cancelled', 'locked']"
-                  decoration-bf="state == 'draft' and product_id == False">
+                  decoration-bf="state == 'draft' and product_id == False"
+                  decoration-danger="deadline and (deadline &lt; current_date)">
                 <field name="name"/>
                 <field name="origin"/>
                 <field name="user_id"/>
@@ -208,8 +220,7 @@
                                 </group>
                             </group>
                             <group>
-                                <label for="description" class="oe_edit_only"/>
-                                <field name="description" colspan="4" nolabel="1"/>
+                                <field name="description" widget="html" colspan="4" />
                             </group>
                         </page>
                     </notebook>

--- a/rma_sale/views/sale_views.xml
+++ b/rma_sale/views/sale_views.xml
@@ -10,7 +10,7 @@
                 <button name="action_create_rma"
                         type="object"
                         string="Create RMA"
-                        states="sale"/>
+                        states="sale,done"/>
             </button>
             <div name="button_box">
                 <button name="action_view_rma"


### PR DESCRIPTION
* IMP - Now the description will be an html son we can show rich styles
in the customers report.
* FIX - On locked sale orders it was need to unlock them to be able to open an RMA.
* IMP - Make the description label visible in the backend form so the
user can easily spot it.
* IMP - Added date and deadline filters.
* IMP - Added pending RMAs filter.
* IMP - Added late RMAs filter.
* IMP - Added danger decoration in tree view

cc @Tecnativa TT25890