### PR TITLE
[FIX] rma: pass company as record to procurement

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -1071,7 +1071,7 @@ class Rma(models.Model):
     ):
         self.ensure_one()
         return {
-            'company_id': self.company_id.id,
+            'company_id': self.company_id,
             'group_id': group_id,
             'date_planned': scheduled_date,
             'warehouse_id': warehouse,


### PR DESCRIPTION
This upstream commit expects `company_id` as a record instead of as an
integer id: https://github.com/odoo/odoo/commit/836ff55dc9f473a61f0c50c15fb5468d75959a83

cc @Tecnativa TT26324