### PR TITLE
[12.0][IMP] *rma*: Avoid RMAs of kits until rma_mrp is installed

### DIFF
--- a/rma_sale/views/sale_portal_template.xml
+++ b/rma_sale/views/sale_portal_template.xml
@@ -74,6 +74,10 @@
                                                     <input type="hidden"
                                                            t-attf-name="#{data_index}-product_id"
                                                            t-att-value="data['product'].id"/>
+                                                    <input type="hidden"
+                                                           t-if="data.get('sale_line_id')"
+                                                           t-attf-name="#{data_index}-sale_line_id"
+                                                           t-att-value="data['sale_line_id'].id"/>
                                                 </td>
                                                 <td class="text-right">
                                                     <div id="delivery-rma-qty">

--- a/rma_sale/views/sale_portal_template.xml
+++ b/rma_sale/views/sale_portal_template.xml
@@ -67,7 +67,7 @@
                                 </thead>
                                 <tbody class="request-rma-tbody">
                                     <t t-foreach="data_list" t-as="data">
-                                        <t t-if="data['quantity'] > 0">
+                                        <t t-if="data['quantity'] > 0 and data['picking']">
                                             <tr>
                                                 <td class="text-left">
                                                     <span t-esc="data['product'].display_name"/>
@@ -92,12 +92,10 @@
                                                     </div>
                                                 </td>
                                                 <td class="text-left">
-                                                    <t t-if="data['picking']">
-                                                        <span t-esc="data['picking'].name"/>
-                                                        <input type="hidden"
-                                                            t-attf-name="#{data_index}-picking_id"
-                                                            t-att-value="data['picking'].id"/>
-                                                    </t>
+                                                    <span t-esc="data['picking'].name"/>
+                                                    <input type="hidden"
+                                                        t-attf-name="#{data_index}-picking_id"
+                                                        t-att-value="data['picking'].id"/>
                                                 </td>
                                                 <td class="text-left">
                                                     <select t-attf-name="#{data_index}-operation_id"

--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -62,6 +62,8 @@ class SaleOrderRmaWizard(models.TransientModel):
     def create_and_open_rma(self):
         self.ensure_one()
         rma = self.create_rma()
+        if not rma:
+            return
         for rec in rma:
             rec.action_confirm()
         action = self.env.ref('rma.rma_action').read()[0]
@@ -137,6 +139,7 @@ class SaleOrderLineRmaWizard(models.TransientModel):
     @api.onchange('product_id')
     def onchange_product_id(self):
         self.picking_id = False
+        self.uom_id = self.product_id.uom_id
 
     @api.depends('picking_id')
     def _compute_move_id(self):

--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -134,6 +134,9 @@ class SaleOrderLineRmaWizard(models.TransientModel):
         comodel_name='rma.operation',
         string='Requested operation',
     )
+    sale_line_id = fields.Many2one(
+        comodel_name="sale.order.line",
+    )
     description = fields.Text()
 
     @api.onchange('product_id')
@@ -146,8 +149,10 @@ class SaleOrderLineRmaWizard(models.TransientModel):
         for record in self:
             if record.picking_id:
                 record.move_id = record.picking_id.move_lines.filtered(
-                    lambda r: (r.sale_line_id.product_id == record.product_id
-                               and r.sale_line_id.order_id == record.order_id))
+                    lambda r: (
+                        r.sale_line_id == record.sale_line_id and
+                        r.sale_line_id.product_id == record.product_id
+                        and r.sale_line_id.order_id == record.order_id))
 
     @api.depends('order_id')
     def _compute_allowed_product_ids(self):

--- a/website_rma/controllers/main.py
+++ b/website_rma/controllers/main.py
@@ -26,10 +26,19 @@ class WebsiteRMA(http.Controller):
         """Domain used for the products to be shown in selection of
         the web form.
         """
-        return [
-            ('name', '=ilike', "%{}%".format(q or '')),
+        domain = [
+            ("name", "=ilike", "%{}%".format(q or "")),
             ("sale_ok", "=", True),
         ]
+        # HACK: As there is no glue module for this purpose we have put
+        # this this condition to check that the mrp module is installed.
+        if "bom_ids" in request.env["product.product"]._fields:
+            domain += [
+                "|",
+                ("bom_ids.type", "!=", "phantom"),
+                ("bom_ids", "=", False),
+            ]
+        return domain
 
     @http.route(['/requestrma'], type='http', auth="user", website=True)
     def request_rma(self, **kw):

--- a/website_rma/controllers/main.py
+++ b/website_rma/controllers/main.py
@@ -11,6 +11,7 @@ class WebsiteForm(WebsiteForm):
     def insert_record(self, request, model, values, custom, meta=None):
         if model.model == 'rma':
             values['partner_id'] = request.env.user.partner_id.id
+            values['origin'] = 'Website form'
         res = super(WebsiteForm, self).insert_record(
             request, model, values, custom, meta)
         # Add the customer to the followers, the same as when creating


### PR DESCRIPTION
cc @Tecnativa TT27238

- Avoid creating RMAs from a portal Sales Order page for lines that don't have an associated picking (like Kit lines).
- Avoid creating RMAs from the website RMA for Kit products.

In PR https://github.com/OCA/rma/pull/183/files we are working on handling RMAs for kit products, but meanwhile, it is necessary to avoid creating RMAs from the website and portal for those kit products to avoid errors.