### PR TITLE
[13.0][FIX] website_rma: remove default space characters in website form description input

### DIFF
--- a/website_rma/views/request_rma_form.xml
+++ b/website_rma/views/request_rma_form.xml
@@ -124,11 +124,9 @@
                                                 class="form-control o_website_form_input"
                                                 name="description"
                                                 required=""
-                                            >
-                                                <t
+                                            ><t
                                                     t-esc="request.params.get('description', '')"
-                                                />
-                                            </textarea>
+                                                /></textarea>
                                         </div>
                                     </div>
                                     <div class="form-group row">


### PR DESCRIPTION
Cc @Tecnativa TT27062