### PR TITLE
[FIX] rma_sale: fix wrong values for RMA creation

### DIFF
--- a/rma_sale/controllers/sale_portal.py
+++ b/rma_sale/controllers/sale_portal.py
@@ -25,10 +25,15 @@ class CustomerPortal(CustomerPortal):
             return request.redirect("/my")
         order_obj = request.env["sale.order"]
         wizard_obj = request.env["sale.order.rma.wizard"]
+        wizard_line_field_types = {
+            f: d["type"] for f, d in wizard_obj.line_ids.fields_get().items()
+        }
         # Set wizard line vals
         mapped_vals = {}
         for name, value in post.items():
             row, field_name = name.split("-", 1)
+            if wizard_line_field_types.get(field_name) == "many2one":
+                value = int(value) if value else False
             mapped_vals.setdefault(row, {}).update({field_name: value})
         # If no operation is filled, no RMA will be created
         line_vals = [

--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -130,6 +130,8 @@ class SaleOrderLineRmaWizard(models.TransientModel):
                         and r.sale_line_id.order_id == record.order_id
                     )
                 )
+            else:
+                record.move_id = False
 
     @api.depends("order_id")
     def _compute_allowed_product_ids(self):


### PR DESCRIPTION
Lesser fix for creating RMA from website.
Current values will break any custom behaviour because Many2one fields are set using strings instead of integer (IDs).
This will result, e.g., in having stuff like:
```
>>> self
rma(1,)
>>> self.product_id
product.product('1',)
>>> self.product_id.name
*** odoo.exceptions.AccessError: Database fetch misses ids ('1') and has extra ids (1), may be caused by a type incoherence in a previous request
```