### PR TITLE
[FIX] rma_sale_mrp: handle exceptions when qty is forced

### DIFF
--- a/rma_sale_mrp/tests/test_rma_sale_mrp.py
+++ b/rma_sale_mrp/tests/test_rma_sale_mrp.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.tests import Form, SavepointCase
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 
 class TestRmaSaleMrp(SavepointCase):
@@ -153,3 +153,12 @@ class TestRmaSaleMrp(SavepointCase):
         wizard_id = order.action_create_rma()["res_id"]
         wizard = self.env["sale.order.rma.wizard"].browse(wizard_id)
         self.assertEqual(wizard.line_ids.quantity, 1)
+        wizard.create_and_open_rma()
+        # Now we open the wizard again and try to force the RMA qty wich should
+        # be 0 at this time
+        wizard_id = order.action_create_rma()["res_id"]
+        wizard = self.env["sale.order.rma.wizard"].browse(wizard_id)
+        self.assertEqual(wizard.line_ids.quantity, 0)
+        wizard.line_ids.quantity = 1
+        with self.assertRaises(ValidationError):
+            wizard.create_and_open_rma()

--- a/rma_sale_mrp/wizard/sale_order_rma_wizard.py
+++ b/rma_sale_mrp/wizard/sale_order_rma_wizard.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class SaleOrderRmaWizard(models.TransientModel):
@@ -50,6 +51,12 @@ class SaleOrderRmaWizard(models.TransientModel):
                 product_kit_component_lines = kit_component_lines.filtered(
                     lambda x: x.product_id == product and x.quantity
                 )
+                if not product_kit_component_lines:
+                    raise ValidationError(_(
+                        "The kit corresponding to the product %s can't be "
+                        "put in the RMA. Either all or some of the components "
+                        "where already put in another RMA"
+                    ) % line.product_id.name)
                 qty_to_return = (
                     product_kit_component_lines[0].per_kit_quantity
                     * line.quantity


### PR DESCRIPTION
This PR includes
- Handle the error if a user tries to force the RMA from the backend wizard.
- Allow recurrent RMAs for a product

cc @Tecnativa TT29338

Please review @victoralmau  @pedrobaeza 