### PR TITLE
[FIX] website_rma: controller implementation

### DIFF
--- a/website_rma/controllers/main.py
+++ b/website_rma/controllers/main.py
@@ -9,11 +9,11 @@ from odoo.http import request
 class WebsiteForm(WebsiteForm):
 
     def insert_record(self, request, model, values, custom, meta=None):
-        if model.model == 'rma':
-            values['partner_id'] = request.env.user.partner_id.id
-            values['origin'] = 'Website form'
-        res = super(WebsiteForm, self).insert_record(
-            request, model, values, custom, meta)
+        if model.model != 'rma':
+            return super().insert_record(request, model, values, custom, meta)
+        values['partner_id'] = request.env.user.partner_id.id
+        values['origin'] = 'Website form'
+        res = super().insert_record(request, model, values, custom, meta)
         # Add the customer to the followers, the same as when creating
         # an RMA from a sales order in the portal.
         rma = request.env['rma'].browse(res).sudo()


### PR DESCRIPTION
It was assumed that this method (used for any model) always had an RMA
in return, which wasn't correct at all and could lead to cross-model and
cross-customer subscripting if an RMA id matched the one of the form
model creating (eg.: `crm.lead` in 'Contact Us' form)

cc @Tecnativa TT29397

please review @pedrobaeza @ernestotejeda 