### PR TITLE
[FIX] rma_sale_mrp: kit line with no uom qty

### DIFF
--- a/rma_sale_mrp/models/sale_order.py
+++ b/rma_sale_mrp/models/sale_order.py
@@ -101,7 +101,10 @@ class SaleOrderLine(models.Model):
         rely on the matching of sale order and pickings demands, but if those
         were manually changed, it could lead to inconsistencies"""
         self.ensure_one()
-        if self.product_id and not self.product_id._is_phantom_bom():
+        if (
+            self.product_id and not self.product_id._is_phantom_bom() or
+            not self.product_uom_qty
+        ):
             return 0
         component_demand = sum(
             self.move_ids.filtered(


### PR DESCRIPTION
If a user corrects the original sale order and lowers a kit line quantity
to 0, we don't want to compute anything on it.

cc @Tecnativa TT29669

@pedrobaeza @victoralmau 