### PR TITLE
[IMP] rma: notify reception to customer

### DIFF
--- a/rma/data/mail_data.xml
+++ b/rma/data/mail_data.xml
@@ -8,7 +8,7 @@
         <field name="description">RMA in draft state</field>
     </record>
     <record id="mt_rma_notification" model="mail.message.subtype">
-        <field name="name">RMA Notificatoin</field>
+        <field name="name">RMA Notification</field>
         <field name="res_model">rma</field>
         <field name="default" eval="False"/>
         <field name="description">RMA automatic customer notifications</field>
@@ -51,6 +51,62 @@
     % endif
     <br /><br />
     Here is the RMA <strong>${object.name}</strong> from ${object.company_id.name}.
+    <br /><br />
+    Do not hesitate to contact us if you have any question.
+</p>
+</div>
+        </field>
+    </record>
+    <!--RMA receipt confirmation email template -->
+    <record id="mail_template_rma_receipt_notification" model="mail.template">
+        <field name="name">RMA Receipt Notification</field>
+        <field name="model_id" ref="model_rma"/>
+        <field name="email_from">${object.user_id.email_formatted |safe}</field>
+        <field name="partner_to">${object.partner_id.id}</field>
+        <field name="subject">${object.company_id.name} RMA (Ref ${object.name or 'n/a' }) products received</field>
+        <field name="report_template" ref="report_rma_action" />
+        <field name="report_name">${(object.name or '')}</field>
+        <field name="lang">${object.partner_id.lang}</field>
+        <field name="user_signature" eval="True"/>
+        <field name="auto_delete" eval="True"/>
+        <field name="body_html" type="html">
+<div style="margin: 0px; padding: 0px;">
+<p style="margin: 0px; padding: 0px; font-size: 13px;">
+    Dear ${object.partner_id.name}
+    % if object.partner_id.parent_id:
+        (${object.partner_id.parent_id.name})
+    % endif
+    <br /><br />
+    The products for your RMA <strong>${object.name}</strong>
+    from ${object.company_id.name} have been received in our warehouse.
+    <br /><br />
+    Do not hesitate to contact us if you have any question.
+</p>
+</div>
+        </field>
+    </record>
+    <record id="mail_template_rma_draft_notification" model="mail.template">
+        <field name="name">RMA Draft Notification</field>
+        <field name="model_id" ref="model_rma"/>
+        <field name="email_from">${object.user_id.email_formatted |safe}</field>
+        <field name="partner_to">${object.partner_id.id}</field>
+        <field name="subject">${object.company_id.name} Your RMA has been succesfully created (Ref ${object.name or 'n/a' })</field>
+        <field name="report_template" ref="report_rma_action" />
+        <field name="report_name">${(object.name or '')}</field>
+        <field name="lang">${object.partner_id.lang}</field>
+        <field name="user_signature" eval="True"/>
+        <field name="auto_delete" eval="True"/>
+        <field name="body_html" type="html">
+<div style="margin: 0px; padding: 0px;">
+<p style="margin: 0px; padding: 0px; font-size: 13px;">
+    Dear ${object.partner_id.name}
+    % if object.partner_id.parent_id:
+        (${object.partner_id.parent_id.name})
+    % endif
+    <br /><br />
+    You've succesfully placed your RMA <strong>${object.name}</strong>
+    on ${object.company_id.name}. Our team will check it and will validate
+    it as soon as possible.
     <br /><br />
     Do not hesitate to contact us if you have any question.
 </p>

--- a/rma/models/res_company.py
+++ b/rma/models/res_company.py
@@ -13,10 +13,31 @@ class Company(models.Model):
         except ValueError:
             return False
 
+    def _default_rma_mail_receipt_template(self):
+        try:
+            return self.env.ref("rma.mail_template_rma_receipt_notification").id
+        except ValueError:
+            return False
+
+    def _default_rma_mail_draft_template(self):
+        try:
+            return self.env.ref("rma.mail_template_rma_draft_notification").id
+        except ValueError:
+            return False
+
     send_rma_confirmation = fields.Boolean(
         string="Send RMA Confirmation",
         help="When the delivery is confirmed, send a confirmation email "
              "to the customer.",
+    )
+    send_rma_receipt_confirmation = fields.Boolean(
+        string="Send RMA Receipt Confirmation",
+        help="When the RMA receipt is confirmed, send a confirmation email "
+             "to the customer.",
+    )
+    send_rma_draft_confirmation = fields.Boolean(
+        string="Send RMA draft Confirmation",
+        help="When a customer places an RMA, send a notification with it",
     )
     rma_mail_confirmation_template_id = fields.Many2one(
         comodel_name="mail.template",
@@ -24,6 +45,21 @@ class Company(models.Model):
         domain="[('model', '=', 'rma')]",
         default=_default_rma_mail_confirmation_template,
         help="Email sent to the customer once the RMA is confirmed.",
+    )
+    rma_mail_receipt_confirmation_template_id = fields.Many2one(
+        comodel_name="mail.template",
+        string="Email Template receipt confirmation for RMA",
+        domain="[('model', '=', 'rma')]",
+        default=_default_rma_mail_receipt_template,
+        help="Email sent to the customer once the RMA products are received.",
+    )
+    rma_mail_draft_confirmation_template_id = fields.Many2one(
+        comodel_name="mail.template",
+        string="Email Template draft notification for RMA",
+        domain="[('model', '=', 'rma')]",
+        default=_default_rma_mail_draft_template,
+        help="Email sent to the customer when they place "
+             "an RMA from the portal",
     )
 
     @api.model

--- a/rma/models/res_config_settings.py
+++ b/rma/models/res_config_settings.py
@@ -14,3 +14,19 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.rma_mail_confirmation_template_id",
         readonly=False,
     )
+    send_rma_receipt_confirmation = fields.Boolean(
+        related="company_id.send_rma_receipt_confirmation",
+        readonly=False,
+    )
+    rma_mail_receipt_confirmation_template_id = fields.Many2one(
+        related="company_id.rma_mail_receipt_confirmation_template_id",
+        readonly=False,
+    )
+    send_rma_draft_confirmation = fields.Boolean(
+        related="company_id.send_rma_draft_confirmation",
+        readonly=False,
+    )
+    rma_mail_draft_confirmation_template_id = fields.Many2one(
+        related="company_id.rma_mail_draft_confirmation_template_id",
+        readonly=False,
+    )

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -513,7 +513,13 @@ class Rma(models.Model):
         # Assign a default team_id which will be the first in the sequence
         if "team_id" not in vals:
             vals["team_id"] = self.env["rma.team"].search([], limit=1).id
-        return super().create(vals)
+        rmas = super().create(vals)
+        # Send acknowledge when the RMA is created from the portal and the
+        # company has the proper setting active. This context is set by the
+        # `rma_sale` module.
+        if self.env.context.get("from_portal"):
+            rmas._send_draft_email()
+        return rmas
 
     @api.multi
     def copy(self, default=None):
@@ -529,6 +535,18 @@ class Rma(models.Model):
                 _("You cannot delete RMAs that are not in draft state"))
         return super().unlink()
 
+    def _send_draft_email(self):
+        """Send customer notifications they place the RMA from the portal"""
+        for rma in self.filtered("company_id.send_rma_draft_confirmation"):
+            rma_template_id = (
+                rma.company_id.rma_mail_draft_confirmation_template_id.id
+            )
+            rma.with_context(
+                force_send=True,
+                mark_rma_as_sent=True,
+                default_subtype_id=self.env.ref("rma.mt_rma_notification").id,
+            ).message_post_with_template(rma_template_id)
+
     def _send_confirmation_email(self):
         """Auto send notifications"""
         for rma in self.filtered(lambda p: p.company_id.send_rma_confirmation):
@@ -539,6 +557,18 @@ class Rma(models.Model):
                 force_send=True,
                 mark_rma_as_sent=True,
                 default_subtype_id=self.env.ref('rma.mt_rma_notification').id,
+            ).message_post_with_template(rma_template_id)
+
+    def _send_receipt_confirmation_email(self):
+        """Send customer notifications when the products are received"""
+        for rma in self.filtered("company_id.send_rma_receipt_confirmation"):
+            rma_template_id = (
+                rma.company_id.rma_mail_receipt_confirmation_template_id.id
+            )
+            rma.with_context(
+                force_send=True,
+                mark_rma_as_sent=True,
+                default_subtype_id=self.env.ref("rma.mt_rma_notification").id,
             ).message_post_with_template(rma_template_id)
 
     # Action methods
@@ -1203,6 +1233,16 @@ class Rma(models.Model):
         return 'RMA Report - %s' % self.name
 
     # Other business methods
+
+    def update_received_state_on_reception(self):
+        """ Invoked by:
+            [stock.move]._action_done
+            Here we can attach methods to trigger when the customer products
+            are received on the RMA location, such as automatic notifications
+        """
+        self.write({"state": "received"})
+        self._send_receipt_confirmation_email()
+
     def update_received_state(self):
         """ Invoked by:
          [stock.move].unlink

--- a/rma/models/stock_move.py
+++ b/rma/models/stock_move.py
@@ -72,7 +72,7 @@ class StockMove(models.Model):
         # if the stock user has no RMA permissions.
         to_be_received = move_done.sudo().mapped('rma_receiver_ids').filtered(
             lambda r: r.state == 'confirmed')
-        to_be_received.write({'state': 'received'})
+        to_be_received.update_received_state_on_reception()
         # Set RMAs as delivered
         move_done.mapped('rma_id').update_replaced_state()
         move_done.mapped('rma_id').update_returned_state()

--- a/rma/views/res_config_settings_views.xml
+++ b/rma/views/res_config_settings_views.xml
@@ -22,6 +22,38 @@
                         </div>
                     </div>
                 </div>
+                <div class="col-12 col-lg-6 o_setting_box" title="Send automatic RMA products reception notification to customer">
+                    <div class="o_setting_left_pane">
+                        <field name="send_rma_receipt_confirmation"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="send_rma_receipt_confirmation" string="RMA Receipt Confirmation Email"/>
+                        <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
+                        <div class="text-muted">
+                            When the RMA products are received, send an automatic information email.
+                        </div>
+                        <div class="row mt16" attrs="{'invisible': [('send_rma_receipt_confirmation', '=', False)]}">
+                            <label for="rma_mail_receipt_confirmation_template_id" string="Email Template" class="col-lg-4 o_light_label"/>
+                            <field name="rma_mail_receipt_confirmation_template_id" class="oe_inline" attrs="{'required': [('send_rma_receipt_confirmation', '=', True)]}" context="{'default_model': 'rma'}"/>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-lg-6 o_setting_box" title="Send automatic notification when the customer places an RMA">
+                    <div class="o_setting_left_pane">
+                        <field name="send_rma_draft_confirmation"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="send_rma_draft_confirmation" string="RMA draft notification Email"/>
+                        <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
+                        <div class="text-muted">
+                            When customers themselves place an RMA from the portal, send an automatic notification acknowleging it.
+                        </div>
+                        <div class="row mt16" attrs="{'invisible': [('send_rma_draft_confirmation', '=', False)]}">
+                            <label for="rma_mail_draft_confirmation_template_id" string="Email Template" class="col-lg-4 o_light_label"/>
+                            <field name="rma_mail_draft_confirmation_template_id" class="oe_inline" attrs="{'required': [('send_rma_draft_confirmation', '=', True)]}" context="{'default_model': 'rma'}"/>
+                        </div>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Now we can configure if an automatic notification should be sent when we
receive the goods from an RMA in our warehouse

If we've got `rma_sale` or `website_rma` we can also configure draft
notifications so when the customer places an RMA from the portal the
receive an acknowledge email.

cc @Tecnativa TT29595

ping @CarlosRoca13 @victoralmau 