### PR TITLE
[FIX] rma_sale: chained returns

### DIFF
--- a/rma_sale/models/sale.py
+++ b/rma_sale/models/sale.py
@@ -133,12 +133,19 @@ class SaleOrderLine(models.Model):
                 qty = move.product_uom_qty
                 qty_returned = 0
                 move_dest = destination_moves(move)
+                # With the return of the return of the return we could have an
+                # infinite loop, so we should avoid it dropping already explored
+                # move_dest_ids
+                visited_moves = move + move_dest
                 while move_dest:
                     qty_returned -= sum(move_dest.mapped("product_uom_qty"))
-                    move_dest = destination_moves(move_dest)
+                    move_dest = destination_moves(move_dest) - visited_moves
                     if move_dest:
+                        visited_moves += move_dest
                         qty += sum(move_dest.mapped("product_uom_qty"))
-                        move_dest = destination_moves(move_dest)
+                        move_dest = (
+                            destination_moves(move_dest) - visited_moves
+                        )
                 # If by chance we get a negative qty we should ignore it
                 qty = max(0, sum((qty, qty_returned)))
                 data.append({


### PR DESCRIPTION
Using move_dest_ids we can easily end in an infinite loop situation as
the return of the return of the return ends with some original moves on
in move_dest_ids. We must ensure to drop them to avoid the infinite
loop.

cc @Tecnativa TT29886

ping @pedrobaeza @Yajo 