### PR TITLE
[IMP] rma_sale: portal rma request single page view

### DIFF
--- a/rma_sale/__manifest__.py
+++ b/rma_sale/__manifest__.py
@@ -20,6 +20,7 @@
         "views/rma_views.xml",
         "views/sale_views.xml",
         "views/sale_portal_template.xml",
+        "views/res_config_settings_views.xml",
         "wizard/sale_order_rma_wizard_views.xml",
     ],
 }

--- a/rma_sale/models/__init__.py
+++ b/rma_sale/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
+from . import res_company
+from . import res_config_settings
 from . import rma
 from . import sale
 from . import stock_move

--- a/rma_sale/models/res_company.py
+++ b/rma_sale/models/res_company.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    show_full_page_sale_rma = fields.Boolean(
+        string="Full page RMA creation",
+        help="From the frontend sale order page go to a single RMA page "
+             "creation instead of the usual popup",
+    )

--- a/rma_sale/models/res_config_settings.py
+++ b/rma_sale/models/res_config_settings.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    show_full_page_sale_rma = fields.Boolean(
+        related="company_id.show_full_page_sale_rma",
+        readonly=False,
+    )

--- a/rma_sale/views/res_config_settings_views.xml
+++ b/rma_sale/views/res_config_settings_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='sale_management']/div[hasclass('o_settings_container')]" position="inside">
+                <div class="col-12 col-lg-6 o_setting_box" title="Show portal RMA request in a single page">
+                    <div class="o_setting_left_pane">
+                        <field name="show_full_page_sale_rma"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="show_full_page_sale_rma" string="Single page RMA request"/>
+                        <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." groups="base.group_multi_company"/>
+                        <div class="text-muted">
+                            When we hit the RMA request button from the portal sale page, open in a single page instead of a popup.
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/rma_sale/views/sale_portal_template.xml
+++ b/rma_sale/views/sale_portal_template.xml
@@ -1,145 +1,156 @@
 <odoo>
+    <!-- Call this form via controller to add it to an independent page -->
+    <template id="sale_rma_request_form" name="RMA Request Form">
+        <form id="form-request-rma" method="POST" t-attf-action="/my/orders/#{sale_order.id}/requestrma?access_token=#{sale_order.access_token}" t-att-class="not single_page_mode and 'modal-content' or 'col-12'">
+            <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+            <header class="modal-header" t-if="not single_page_mode">
+                <h4 class="modal-title">Request RMAs</h4>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">&amp;times;</button>
+            </header>
+            <main t-att-class="not single_page_mode and 'modal-body'" id="modal-body-request-rma">
+                <div class="alert alert-info mb-2 mb-sm-1 oe_structure" role="alert">
+                    <span>
+                    You're about to perform an RMA request. Our team will process it an will reach you once it's validated. Keep in mind that:
+                    <ul>
+                        <li>Select the product quantity and the requested operation</li>
+                        <li>Use the comment button to add relevant information regarding the RMA, like returned serial numbers or a description of the issue</li>
+                        <li>If no requested operation is set, the RMA won't be correctly fulfilled</li>
+                        <li>You can only return as much product units as you received for this order</li>
+                        <li>The limit will decrease when the units in other RMAs are confirmed</li>
+                        <li>You can send a message in every RMA sent</li>
+                    </ul>
+                    </span>
+                </div>
+                <t
+                    t-set="delivery_addresses"
+                    t-value="sale_order.partner_shipping_id | sale_order.partner_id.commercial_partner_id.mapped('child_ids').filtered(lambda x: x.type in ['contact', 'delivery'])"
+                />
+                <button
+                    class="btn btn-primary btn-block mb8"
+                    type="button" data-toggle="collapse"
+                    data-target="#delivery_address_picker"
+                    aria-expanded="false"
+                ><i class="fa fa-truck" /> Choose a delivery address</button>
+                <div class="col-lg-12 collapse mt8" id="delivery_address_picker">
+                    <div data-toggle="buttons" class="row">
+                        <label t-attf-class="card mr4 btn btn-light #{address == sale_order.partner_shipping_id and 'active' or ''}" t-foreach="delivery_addresses" t-as="address">
+                                <input class="d-none" type="radio" name="partner_shipping_id" t-att-value="address.id">
+                                    <strong>
+                                        <i t-attf-class="text-secondary fa #{address.type == 'delivery' and 'fa-truck' or 'fa-user'}" />
+                                        <t t-esc="address.name"/>
+                                    </strong>
+                                    <pre><h6 t-esc="address.contact_address" /></pre>
+                                </input>
+                        </label>
+                    </div>
+                </div>
+                <t t-set="data_list" t-value="sale_order.get_delivery_rma_data()"/>
+                <t t-set="operations" t-value="sale_order.env['rma.operation'].search([])"/>
+                <table class="table table-sm" id="request-rma-table">
+                    <thead class="bg-100">
+                        <tr>
+                            <th class="text-left">Product</th>
+                            <th class="text-right">Quantity</th>
+                            <th class="text-left">Delivery</th>
+                            <th class="text-left">Requested operation</th>
+                            <th name="portal_rma_button_desc" />
+                        </tr>
+                    </thead>
+                    <tbody class="request-rma-tbody">
+                        <t t-foreach="data_list" t-as="data">
+                            <t t-if="data['quantity'] > 0 and data['picking']">
+                                <tr>
+                                    <td class="text-left">
+                                        <span t-esc="data['product'].display_name"/>
+                                        <input type="hidden"
+                                               t-attf-name="#{data_index}-product_id"
+                                               t-att-value="data['product'].id"/>
+                                        <input type="hidden"
+                                               t-if="data.get('sale_line_id')"
+                                               t-attf-name="#{data_index}-sale_line_id"
+                                               t-att-value="data['sale_line_id'].id"/>
+                                    </td>
+                                    <td class="text-right">
+                                        <div id="delivery-rma-qty">
+                                            <input type="number"
+                                                   t-attf-name="#{data_index}-quantity"
+                                                   class="o_input text-right"
+                                                   placeholder="0"
+                                                   min="0"
+                                                   t-att-max="data['quantity']"
+                                                   t-att-value="0"
+                                                   style="max-width: 60px;"/>
+                                            <span t-esc="data['uom'].name" groups="uom.group_uom"/>
+                                            <input type="hidden"
+                                                   t-attf-name="#{data_index}-uom_id"
+                                                   t-att-value="data['uom'].id"/>
+                                        </div>
+                                    </td>
+                                    <td class="text-left">
+                                        <span t-esc="data['picking'] and data['picking'].name"/>
+                                        <input type="hidden"
+                                            t-attf-name="#{data_index}-picking_id"
+                                            t-att-value="data['picking'] and data['picking'].id"/>
+                                    </td>
+                                    <td class="text-left">
+                                        <select t-attf-name="#{data_index}-operation_id"
+                                                class="form-control rma-operation">
+                                            <option value="">---</option>
+                                            <t t-foreach="operations" t-as="operation">
+                                                <option t-att-value="operation.id">
+                                                    <t t-esc="operation.name" />
+                                                </option>
+                                            </t>
+                                        </select>
+                                    </td>
+                                    <td>
+                                        <button
+                                            class="btn btn-primary fa fa-comments"
+                                            type="button" data-toggle="collapse"
+                                            t-attf-data-target="#comment-#{data_index}"
+                                            aria-expanded="false"
+                                            t-attf-aria-controls="comment-#{data_index}" />
+                                    </td>
+                                </tr>
+                                <tr class="collapse" t-attf-id="comment-#{data_index}">
+                                    <td colspan="5">
+                                        <textarea
+                                            class="form-control o_website_form_input"
+                                            t-attf-name="#{data_index}-description"
+                                            placeholder="Comment anything relevant to the return, like serial numbers, a description of the issue, etc"
+                                        />
+                                    </td>
+                                </tr>
+                            </t>
+                        </t>
+                    </tbody>
+                </table>
+            </main>
+            <footer class="modal-footer">
+                <button type="submit" t-att-id="sale_order.id" class="btn btn-primary"><i class="fa fa-check"></i> Request RMAs</button>
+                <button type="button" class="btn btn-danger" data-dismiss="modal"><i class="fa fa-times"></i> Cancel</button>
+            </footer>
+        </form>
+    </template>
     <template id="sale_order_portal_template" name="Request RMA" inherit_id="sale.sale_order_portal_template">
         <xpath expr="//div[hasclass('o_portal_sale_sidebar')]//div[hasclass('o_download_pdf')]/.." position="after">
             <li t-if="sale_order.state in ['sale', 'done']" class="list-group-item flex-grow-1" id="li-request-rma">
-                <a role="button" class="btn btn-secondary btn-block mb8" data-toggle="modal" data-target="#modal-request-rma" href="#">
-                    <i class="fa fa-reply"/> Request RMAs
-                </a>
+                <t t-if="sale_order.company_id.show_full_page_sale_rma">
+                    <a role="button" class="btn btn-secondary btn-block mb8" t-attf-href="/my/requestrma/#{sale_order.id}">
+                        <i class="fa fa-reply"/> Request RMAs
+                    </a>
+                </t>
+                <t t-else="">
+                    <a role="button" class="btn btn-secondary btn-block mb8" data-toggle="modal" data-target="#modal-request-rma" href="#">
+                        <i class="fa fa-reply"/> Request RMAs
+                    </a>
+                </t>
             </li>
         </xpath>
         <xpath expr="//div[@id='modaldecline']" position="after">
-            <div role="dialog" class="modal fade" id="modal-request-rma">
+            <div role="dialog" class="modal fade" id="modal-request-rma" t-if="not sale_order.company_id.show_full_page_sale_rma">
                 <div class="modal-dialog" style="max-width: 1000px;">
-                    <form id="form-request-rma" method="POST" t-attf-action="/my/orders/#{sale_order.id}/requestrma?access_token=#{sale_order.access_token}" class="modal-content">
-                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
-                        <header class="modal-header">
-                            <h4 class="modal-title">Request RMAs</h4>
-                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">&amp;times;</button>
-                        </header>
-                        <main class="modal-body" id="modal-body-request-rma">
-                            <div class="alert alert-info mb-2 mb-sm-1" role="alert">
-                                <span>
-                                You're about to perform an RMA request. Our team will process it an will reach you once it's validated. Keep in mind that:
-                                <ul>
-                                    <li>Select the product quantity and the requested operation</li>
-                                    <li>Use the comment button to add relevant information regarding the RMA, like returned serial numbers or a description of the issue</li>
-                                    <li>If no requested operation is set, the RMA won't be correctly fulfilled</li>
-                                    <li>You can only return as much product units as you received for this order</li>
-                                    <li>The limit will decrease when the units in other RMAs are confirmed</li>
-                                    <li>You can send a message in every RMA sent</li>
-                                </ul>
-                                </span>
-                            </div>
-                            <t
-                                t-set="delivery_addresses"
-                                t-value="sale_order.partner_shipping_id | sale_order.partner_id.commercial_partner_id.mapped('child_ids').filtered(lambda x: x.type in ['contact', 'delivery'])"
-                            />
-                            <button
-                                class="btn btn-primary btn-block mb8"
-                                type="button" data-toggle="collapse"
-                                data-target="#delivery_address_picker"
-                                aria-expanded="false"
-                            ><i class="fa fa-truck" /> Choose a delivery address</button>
-                            <div class="col-lg-12 collapse mt8" id="delivery_address_picker">
-                                <div data-toggle="buttons" class="row">
-                                    <label t-attf-class="card mr4 btn btn-light #{address == sale_order.partner_shipping_id and 'active' or ''}" t-foreach="delivery_addresses" t-as="address">
-                                            <input class="d-none" type="radio" name="partner_shipping_id" t-att-value="address.id">
-                                                <strong>
-                                                    <i t-attf-class="text-secondary fa #{address.type == 'delivery' and 'fa-truck' or 'fa-user'}" />
-                                                    <t t-esc="address.name"/>
-                                                </strong>
-                                                <pre><h6 t-esc="address.contact_address" /></pre>
-                                            </input>
-                                    </label>
-                                </div>
-                            </div>
-                            <t t-set="data_list" t-value="sale_order.get_delivery_rma_data()"/>
-                            <t t-set="operations" t-value="sale_order.env['rma.operation'].search([])"/>
-                            <table class="table table-sm" id="request-rma-table">
-                                <thead class="bg-100">
-                                    <tr>
-                                        <th class="text-left">Product</th>
-                                        <th class="text-right">Quantity</th>
-                                        <th class="text-left">Delivery</th>
-                                        <th class="text-left">Requested operation</th>
-                                        <th name="portal_rma_button_desc" />
-                                    </tr>
-                                </thead>
-                                <tbody class="request-rma-tbody">
-                                    <t t-foreach="data_list" t-as="data">
-                                        <t t-if="data['quantity'] > 0 and data['picking']">
-                                            <tr>
-                                                <td class="text-left">
-                                                    <span t-esc="data['product'].display_name"/>
-                                                    <input type="hidden"
-                                                           t-attf-name="#{data_index}-product_id"
-                                                           t-att-value="data['product'].id"/>
-                                                    <input type="hidden"
-                                                           t-if="data.get('sale_line_id')"
-                                                           t-attf-name="#{data_index}-sale_line_id"
-                                                           t-att-value="data['sale_line_id'].id"/>
-                                                </td>
-                                                <td class="text-right">
-                                                    <div id="delivery-rma-qty">
-                                                        <input type="number"
-                                                               t-attf-name="#{data_index}-quantity"
-                                                               class="o_input text-right"
-                                                               placeholder="0"
-                                                               min="0"
-                                                               t-att-max="data['quantity']"
-                                                               t-att-value="0"
-                                                               style="max-width: 60px;"/>
-                                                        <span t-esc="data['uom'].name" groups="uom.group_uom"/>
-                                                        <input type="hidden"
-                                                               t-attf-name="#{data_index}-uom_id"
-                                                               t-att-value="data['uom'].id"/>
-                                                    </div>
-                                                </td>
-                                                <td class="text-left">
-                                                    <span t-esc="data['picking'] and data['picking'].name"/>
-                                                    <input type="hidden"
-                                                        t-attf-name="#{data_index}-picking_id"
-                                                        t-att-value="data['picking'] and data['picking'].id"/>
-                                                </td>
-                                                <td class="text-left">
-                                                    <select t-attf-name="#{data_index}-operation_id"
-                                                            class="form-control rma-operation">
-                                                        <option value="">---</option>
-                                                        <t t-foreach="operations" t-as="operation">
-                                                            <option t-att-value="operation.id">
-                                                                <t t-esc="operation.name" />
-                                                            </option>
-                                                        </t>
-                                                    </select>
-                                                </td>
-                                                <td>
-                                                    <button
-                                                        class="btn btn-primary fa fa-comments"
-                                                        type="button" data-toggle="collapse"
-                                                        t-attf-data-target="#comment-#{data_index}"
-                                                        aria-expanded="false"
-                                                        t-attf-aria-controls="comment-#{data_index}" />
-                                                </td>
-                                            </tr>
-                                            <tr class="collapse" t-attf-id="comment-#{data_index}">
-                                                <td colspan="5">
-                                                    <textarea
-                                                        class="form-control o_website_form_input"
-                                                        t-attf-name="#{data_index}-description"
-                                                        placeholder="Comment anything relevant to the return, like serial numbers, a description of the issue, etc"
-                                                    />
-                                                </td>
-                                            </tr>
-                                        </t>
-                                    </t>
-                                </tbody>
-                            </table>
-                        </main>
-                        <footer class="modal-footer">
-                            <button type="submit" t-att-id="sale_order.id" class="btn btn-primary"><i class="fa fa-check"></i> Request RMAs</button>
-                            <button type="button" class="btn btn-danger" data-dismiss="modal"><i class="fa fa-times"></i> Cancel</button>
-                        </footer>
-                    </form>
+                    <t t-call="rma_sale.sale_rma_request_form" />
                 </div>
             </div>
         </xpath>
@@ -175,6 +186,46 @@
                     <span t-field="rma.operation_id"/>
                 </div>
             </div>
+        </xpath>
+    </template>
+
+    <!-- Request RMA single view. When the website is installed, we can customize it adding blocks -->
+    <template id="request_rma_single_page" name="Request RMA (single page)">
+        <t t-call="portal.portal_layout">
+            <t t-call="portal.portal_record_layout">
+                <t t-set="card_header">
+                    <h5 class="mb-0">
+                        <span>
+                            RMA request for order <t t-esc="sale_order.name" />
+                        </span>
+                    </h5>
+                </t>
+                <t t-set="card_body">
+                    <div class="oe_structure" id="sale_rma_request_top_hook" />
+                    <div id="request_form">
+                        <div class="row">
+                            <t t-call="rma_sale.sale_rma_request_form">
+                                <t t-set="single_page_mode" t-value="True" />
+                            </t>
+                        </div>
+                    </div>
+                    <div class="oe_structure" id="sale_rma_request_bottom_hook" />
+                </t>
+            </t>
+        </t>
+    </template>
+    <!-- This way we can go back to the origin sale order easily -->
+    <template id="portal_my_home_menu_sale" inherit_id="sale.portal_my_home_menu_sale" priority="99">
+        <xpath expr="//li[@t-if='sale_order']" position="before">
+            <t t-if="page_name != 'request_rma'" name="sale_breadcrumb" />
+            <t t-else="">
+                <li class="breadcrumb-item active">
+                    <a t-if="sale_order" t-att-href="default_url"><t t-esc="sale_order.name"/></a>
+                </li>
+            </t>
+        </xpath>
+        <xpath expr="//t[@name='sale_breadcrumb']" position="inside">
+            <xpath expr="//li[@t-if='sale_order']" position="move" />
         </xpath>
     </template>
 </odoo>

--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -38,6 +38,9 @@ class SaleOrderRmaWizard(models.TransientModel):
         string="Shipping Address",
         help="Will be used to return the goods when the RMA is completed",
     )
+    custom_description = fields.Text(
+        help="Values coming from portal RMA request form custom fields",
+    )
 
     def create_rma(self, from_portal=None):
         self.ensure_one()
@@ -172,6 +175,9 @@ class SaleOrderLineRmaWizard(models.TransientModel):
         partner_shipping = (
             self.wizard_id.partner_shipping_id or
             self.order_id.partner_shipping_id)
+        description = (
+            (self.description or '') + (self.wizard_id.custom_description or '')
+        )
         return {
             'partner_id': self.order_id.partner_id.id,
             'partner_invoice_id': self.order_id.partner_invoice_id.id,
@@ -186,5 +192,5 @@ class SaleOrderLineRmaWizard(models.TransientModel):
             'product_uom_qty': self.quantity,
             'product_uom': self.uom_id.id,
             'operation_id': self.operation_id.id,
-            'description': self.description,
+            'description': description,
         }

--- a/rma_sale_mrp/views/sale_order_portal_template.xml
+++ b/rma_sale_mrp/views/sale_order_portal_template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="sale_order_portal_template" name="Request RMA MRP" inherit_id="rma_sale.sale_order_portal_template">
+    <template id="sale_order_portal_template" name="Request RMA MRP" inherit_id="rma_sale.sale_rma_request_form">
         <xpath expr="//input[@t-attf-name='#{data_index}-product_id']" position="after">
             <input type="hidden"
                    t-if="data.get('phantom_bom_product')"


### PR DESCRIPTION
Now it's possible to configure if the portal RMA request form is loaded
in a popup or in a single page.

In that page, we can add custom blocks (if the website is installed) a
customize the form text.

In this commit, we also add the possibility to extend the form view to allow
custom fields that will show up in the RMA description.

cc @Tecnativa TT29670