### PR TITLE
[13.0][FIX] rma: return location

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -50,7 +50,6 @@ class Rma(models.Model):
         comodel_name="res.users",
         string="Responsible",
         index=True,
-        default=lambda self: self.env.user,
         tracking=True,
         states={"locked": [("readonly", True)], "cancelled": [("readonly", True)]},
     )
@@ -491,7 +490,7 @@ class Rma(models.Model):
                     )
                 vals["name"] = ir_sequence.next_by_code("rma")
             # Assign a default team_id which will be the first in the sequence
-            if "team_id" not in vals:
+            if not vals.get("team_id"):
                 vals["team_id"] = self.env["rma.team"].search([], limit=1).id
         rmas = super().create(vals_list)
         # Send acknowledge when the RMA is created from the portal and the

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -864,11 +864,6 @@ class Rma(models.Model):
     # Reception business methods
     def _create_receptions_from_picking(self):
         self.ensure_one()
-        create_vals = {}
-        if self.location_id:
-            create_vals.update(
-                location_id=self.location_id.id, picking_id=self.picking_id.id,
-            )
         stock_return_picking_form = Form(
             self.env["stock.return.picking"].with_context(
                 active_ids=self.picking_id.ids,
@@ -876,6 +871,8 @@ class Rma(models.Model):
                 active_model="stock.picking",
             )
         )
+        if self.location_id:
+            stock_return_picking_form.location_id = self.location_id
         return_wizard = stock_return_picking_form.save()
         return_wizard.product_return_moves.filtered(
             lambda r: r.move_id != self.move_id


### PR DESCRIPTION
Added changes:

- The new implementation wasn't getting the value set in the wizard.
- Having a default responsible value as it was defined doesn't behave right when the user it's a portal one or the petition comes from a sudo().
- Also, by design it was expected to have a default team if it wasn't defined, but as it was implemented that wasn't possible.


cc @Tecnativa TT32046

ping @ernestotejeda @pedrobaeza 