### PR TITLE
[FIX] fix filter rma location based on the sale order company

### DIFF
--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -9,7 +9,12 @@ class SaleOrderRmaWizard(models.TransientModel):
     _description = "Sale Order Rma Wizard"
 
     def _domain_location_id(self):
-        rma_loc = self.env["stock.warehouse"].search([]).mapped("rma_loc_id")
+        sale = self.env["sale.order"].browse(self.env.context.get("active_id"))
+        rma_loc = (
+            self.env["stock.warehouse"]
+            .search([("company_id", "=", sale.company_id.id)])
+            .mapped("rma_loc_id")
+        )
         return [("id", "child_of", rma_loc.ids)]
 
     order_id = fields.Many2one(


### PR DESCRIPTION
In case of multicompany (working on several company at the same time, or having the right to see warehouse but not location of other company ...), we should only propose the location based on the company of the sale order.
