### PR TITLE
[14.0][FIX] multi company error on rma location choice

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -18,7 +18,14 @@ class Rma(models.Model):
     _inherit = ["mail.thread", "portal.mixin", "mail.activity.mixin"]
 
     def _domain_location_id(self):
-        rma_loc = self.env["stock.warehouse"].search([]).mapped("rma_loc_id")
+        # this is done with sudo, intercompany rules are not applied by default so we
+        # add company in domain explicitly to avoid multi-company rule error when
+        # the user will try to choose a location
+        rma_loc = (
+            self.env["stock.warehouse"]
+            .search([("company_id", "in", self.env.companies.ids)])
+            .mapped("rma_loc_id")
+        )
         return [("id", "child_of", rma_loc.ids)]
 
     # General fields


### PR DESCRIPTION
In a multi company environment, one the RMA form, we get an error when trying to fill the "location" field.

Explanation : 
The location_id field has a method `_domain_location_id` which search all rma locations from all warehouse (no domain).
Problem is, these domain method are called with sudo mode. So the domain will always be set with the RMA location from all database warehouse (from all database companies).
(easy to reproduce on demo database)

Then, when filling the field, we get a multi company access error as the user is actually not allowed to access all companies.
Workaround is to explicitly set company_id in the warehouse domain.

@pedrobaeza @chienandalu @ernestotejeda 