### PR TITLE
[14.0][FIX] rma: duplicate labels category_id and uom_category_id in rma

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -255,7 +255,9 @@ class Rma(models.Model):
         digits="Product Unit of Measure",
         compute="_compute_remaining_qty",
     )
-    uom_category_id = fields.Many2one(related="product_id.uom_id.category_id")
+    uom_category_id = fields.Many2one(
+        related="product_id.uom_id.category_id", string="Category UoM"
+    )
     # Split fields
     can_be_split = fields.Boolean(
         compute="_compute_can_be_split",


### PR DESCRIPTION
Rename label because of duplicate labels in rma  (category_id and uom_category_id) to avoid warning and duplicate filters in search view.
