### PR TITLE
[FIX] rma: return wizard to_refund

### DIFF
--- a/rma/__manifest__.py
+++ b/rma/__manifest__.py
@@ -10,7 +10,7 @@
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "maintainers": ["ernestotejeda"],
     "license": "AGPL-3",
-    "depends": ["account", "stock"],
+    "depends": ["stock_account"],
     "data": [
         "views/report_rma.xml",
         "report/report.xml",

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -877,7 +877,14 @@ class Rma(models.Model):
             lambda r: r.move_id != self.move_id
         ).unlink()
         return_line = return_wizard.product_return_moves
-        return_line.quantity = self.product_uom_qty
+        return_line.update(
+            {
+                "quantity": self.product_uom_qty,
+                # The to_refund field is now True by default, which isn't right in the RMA
+                # creation context.
+                "to_refund": False,
+            }
+        )
         # set_rma_picking_type is to override the copy() method of stock
         # picking and change the default picking type to rma picking type.
         picking_action = return_wizard.with_context(


### PR DESCRIPTION
To create the rma we create the core return wizard, which now sets
to_refund to True as default. This isn't right for RMAs anyway.

cc @Tecnativa TT33706

ping @pedrobaeza @ernestotejeda 