### PR TITLE
[14.0][FIX] Do not link reception and delivery move in case of RMA replacement

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -1164,7 +1164,6 @@ class Rma(models.Model):
         self._action_launch_stock_rule(scheduled_date, warehouse, product, qty, uom)
         new_move = self.delivery_move_ids - moves_before
         if new_move:
-            self.reception_move_id.move_dest_ids = [(4, new_move.id)]
             self.message_post(
                 body=_(
                     "Replacement: "


### PR DESCRIPTION
Hello,

In case of returning a product to customer, I understand that the reception move is chained to the delivery move because we send the same product.
But in case of replacement, it is another product, I think it does not make sense to link the reception move to the delivery move in that case. Indeed, it will block the reservation, even if we have another product to send.
Unless I am missing something?

@chienandalu @ernestotejeda 