### PR TITLE
[14.0][RMA] Allow to bypass reception step by a company

### DIFF
--- a/rma/models/res_company.py
+++ b/rma/models/res_company.py
@@ -60,6 +60,7 @@ class Company(models.Model):
         default=_default_rma_mail_draft_template,
         help="Email sent to the customer when they place " "an RMA from the portal",
     )
+    rma_bypass_reception_step = fields.Boolean()
 
     @api.model
     def create(self, vals):

--- a/rma/models/res_config_settings.py
+++ b/rma/models/res_config_settings.py
@@ -35,3 +35,6 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.rma_mail_draft_confirmation_template_id",
         readonly=False,
     )
+    rma_bypass_reception_step = fields.Boolean(
+        related="company_id.rma_bypass_reception_step", readonly=False
+    )

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -748,3 +748,10 @@ class TestRmaCase(TestRma):
         )
         self.assertTrue(rma.name in mail_receipt.subject)
         self.assertTrue("products received" in mail_receipt.subject)
+
+    def test_validation_without_reception_step(self):
+        rma = self._create_rma(self.partner, self.product, 2, self.rma_loc)
+        rma.bypass_reception_step = True
+        rma.action_confirm()
+        self.assertEqual(rma.state, "received")
+        self.assertFalse(rma.can_be_returned)

--- a/rma/views/res_config_settings_views.xml
+++ b/rma/views/res_config_settings_views.xml
@@ -137,6 +137,17 @@
                         </div>
                     </div>
                 </div>
+                <div class="col-12 col-lg-6 o_setting_box" title="Rma Steps">
+                    <div class="o_setting_left_pane">
+                        <field name="rma_bypass_reception_step" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label
+                            for="rma_bypass_reception_step"
+                            string="Do not manage the reception of products in RMAs"
+                        />
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>

--- a/rma/views/rma_views.xml
+++ b/rma/views/rma_views.xml
@@ -303,6 +303,7 @@
                                         options="{'no_create': True, 'no_open': True}"
                                         groups="stock.group_stock_multi_locations"
                                     />
+                                    <field name="bypass_reception_step" />
                                 </group>
                                 <group>
                                     <field name="deadline" />


### PR DESCRIPTION
As  talked here : https://github.com/OCA/rma/issues/210

It depends on https://github.com/OCA/rma/pull/257 for replacement to work.
Else we should just a condition here : https://github.com/OCA/rma/blob/14.0/rma/models/rma.py#L1167 To avoid link the reception move it there is no reception

@chienandalu @ernestotejeda 