### PR TITLE
[FIX] rma_sale_mrp: description

### DIFF
--- a/rma_sale_mrp/wizard/sale_order_rma_wizard.py
+++ b/rma_sale_mrp/wizard/sale_order_rma_wizard.py
@@ -68,6 +68,7 @@ class SaleOrderRmaWizard(models.TransientModel):
                     for kit_line in product_kit_component_lines:
                         kit_line.quantity = min(qty_to_return, kit_line.quantity)
                         kit_line.operation_id = line.operation_id
+                        kit_line.description = line.description
                         kit_line.kit_qty_done = (
                             kit_line.quantity / kit_line.per_kit_quantity
                         )


### PR DESCRIPTION
Forward of

- [x] #259 

- When creating an RMA for a kit from the portal, the description was
lost for the components.

cc @Tecnativa TT34422

ping @pedrobaeza @ernestotejeda 