### PR TITLE
[FIX] rma: refund permissions

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -620,7 +620,9 @@ class Rma(models.Model):
         for rmas in group_dict.values():
             origin = ", ".join(rmas.mapped("name"))
             invoice_form = Form(
-                self.env["account.move"].with_context(
+                self.env["account.move"]
+                .sudo()
+                .with_context(
                     default_type="out_refund", company_id=rmas[0].company_id.id,
                 ),
                 "account.view_move_form",
@@ -646,7 +648,7 @@ class Rma(models.Model):
                     }
                 )
             refund.invoice_origin = origin
-            refund.message_post_with_view(
+            refund.with_user(self.env.uid).message_post_with_view(
                 "mail.message_origin_link",
                 values={"self": refund, "origin": rmas},
                 subtype_id=self.env.ref("mail.mt_note").id,

--- a/rma/security/ir.model.access.csv
+++ b/rma/security/ir.model.access.csv
@@ -11,3 +11,5 @@ access_rma_tag_manager,rma.tag.manager,model_rma_tag,rma_group_manager,1,1,1,1
 access_rma_finalization_portal,rma.finalization.portal,model_rma_finalization,base.group_portal,1,0,0,0
 access_rma_finalization_user_own,rma.finalization.user.own,model_rma_finalization,rma_group_user_own,1,0,0,0
 access_rma_finalization_manager,rma.finalization.manager,model_rma_finalization,rma_group_manager,1,1,1,1
+access_account_move_rma_user,account_move rma_user,account.model_account_move,rma.rma_group_user_own,1,0,0,0
+access_account_move_line_rma_user,account_move_line rma_user,account.model_account_move_line,rma.rma_group_user_own,1,0,0,0

--- a/rma/security/rma_security.xml
+++ b/rma/security/rma_security.xml
@@ -91,6 +91,23 @@
             name="domain_force"
         > ['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
     </record>
+    <!-- Allow to refund RMAs -->
+    <record id="rma_account_move_personal_rule" model="ir.rule">
+        <field name="name">RMA Personal Invoice</field>
+        <field ref="model_account_move" name="model_id" />
+        <field
+            name="domain_force"
+        >[('type', '=', 'out_refund'), '|', ('invoice_user_id', '=', user.id), ('invoice_user_id', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('rma.rma_group_user_own'))]" />
+    </record>
+    <record id="rma_account_move_line_personal_rule" model="ir.rule">
+        <field name="name">RMA Personal Invoice Lines</field>
+        <field ref="model_account_move_line" name="model_id" />
+        <field
+            name="domain_force"
+        >[('move_id.type', '=', 'out_refund'), '|', ('move_id.invoice_user_id', '=', user.id), ('move_id.invoice_user_id', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('rma.rma_group_user_own'))]" />
+    </record>
     <!-- New users will belong to rma_group_user_own  -->
     <record id="base.default_user" model="res.users">
         <field name="groups_id" eval="[(4, ref('rma_group_user_own'))]" />

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -2,13 +2,18 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests import Form, SavepointCase
+from odoo.tests import Form, SavepointCase, new_test_user, users
 
 
 class TestRma(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super(TestRma, cls).setUpClass()
+        cls.user_rma = new_test_user(
+            cls.env,
+            login="user_rma",
+            groups="rma.rma_group_user_own,stock.group_stock_user",
+        )
         cls.res_partner = cls.env["res.partner"]
         cls.product_product = cls.env["product.product"]
         cls.company = cls.env.user.company_id
@@ -262,6 +267,7 @@ class TestRmaCase(TestRma):
         self.assertEqual(rma_1.state, "draft")
         self.assertEqual(rma_2.state, "received")
 
+    @users("__system__", "user_rma")
     def test_action_refund(self):
         rma = self._create_confirm_receive(self.partner, self.product, 10, self.rma_loc)
         self.assertEqual(rma.state, "received")
@@ -278,6 +284,10 @@ class TestRmaCase(TestRma):
         self.assertFalse(rma.can_be_refunded)
         self.assertFalse(rma.can_be_returned)
         self.assertFalse(rma.can_be_replaced)
+        # A regular user can create the refund but only Invoicing users will be able
+        # to edit it and post it
+        if self.env.user.login != "__system__":
+            return
         with Form(rma.refund_line_id.move_id) as refund_form:
             with refund_form.invoice_line_ids.edit(0) as refund_line:
                 refund_line.quantity = 9


### PR DESCRIPTION
Up to v12, account.invoice, was allowed for a wide variety of users. In
this version though, with account.move conversion, those permissions are
quite restricted.

We want to keep the possibility to open a refund for the RMA users.
Although only Invoicing users will be able to post it anyway.

cc @Tecnativa TT34644

please review @pedrobaeza @sergio-teruel 