### PR TITLE
[IMP] rma: optionally group returns to customer

### DIFF
--- a/rma/README.rst
+++ b/rma/README.rst
@@ -56,6 +56,14 @@ If you want to manually finish RMAs, you need to:
 #. Go to *Settings > Inventory*.
 #. Set *Finish RMAs manually* checkbox on.
 
+By default, returns to customer are grouped by shipping address, warehouse and company.
+If you want to avoid this grouping you can:
+
+#. Go to *Settings > Inventory*.
+#. Set *Group RMA returns by customer address and warehouse* checkbox off.
+
+The users will still be able to group those pickings from the wizard.
+
 Usage
 =====
 

--- a/rma/i18n/es.po
+++ b/rma/i18n/es.po
@@ -6,45 +6,41 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-28 15:54+0000\n"
-"PO-Revision-Date: 2022-01-28 15:54+0000\n"
+"POT-Creation-Date: 2022-03-07 16:34+0000\n"
+"PO-Revision-Date: 2022-03-07 17:39+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"Language: es\n"
+"X-Generator: Poedit 2.3\n"
 
 #. module: rma
 #: model:mail.template,report_name:rma.mail_template_rma_draft_notification
 #: model:mail.template,report_name:rma.mail_template_rma_notification
 #: model:mail.template,report_name:rma.mail_template_rma_receipt_notification
 msgid "${(object.name or '')}"
-msgstr ""
+msgstr "${(object.name or '')}"
 
 #. module: rma
 #: model:mail.template,subject:rma.mail_template_rma_notification
 msgid "${object.company_id.name} RMA (Ref ${object.name or 'n/a' })"
-msgstr ""
+msgstr "${object.company_id.name} RMA (Ref ${object.name or 'n/a' })"
 
 #. module: rma
 #: model:mail.template,subject:rma.mail_template_rma_receipt_notification
-msgid ""
-"${object.company_id.name} RMA (Ref ${object.name or 'n/a' }) products "
-"received"
-msgstr ""
-"${object.company_id.name} RMA (Ref ${object.name or 'n/a' }) productos "
-"recibidos"
+msgid "${object.company_id.name} RMA (Ref ${object.name or 'n/a' }) products received"
+msgstr "${object.company_id.name} RMA (Ref ${object.name or 'n/a' }) productos recibidos"
 
 #. module: rma
 #: model:mail.template,subject:rma.mail_template_rma_draft_notification
 msgid ""
-"${object.company_id.name} Your RMA has been succesfully created (Ref "
-"${object.name or 'n/a' })"
+"${object.company_id.name} Your RMA has been succesfully created (Ref ${object.name or 'n/"
+"a' })"
 msgstr ""
-"${object.company_id.name} Su RMA se ha creado con éxito (Ref ${object.name "
-"or 'n/a' })"
+"${object.company_id.name} Su RMA se ha creado con éxito (Ref ${object.name or 'n/a' })"
 
 #. module: rma
 #: code:addons/rma/models/rma_team.py:0
@@ -57,8 +53,8 @@ msgstr "%s (copia)"
 #, python-format
 msgid "<b>E-mail subject:</b> %s<br/><br/><b>E-mail body:</b><br/>%s"
 msgstr ""
-"<b>Asunto del correo electrónico:</b> %s<br/><br/><b>Cuerpo del correo "
-"electrónico:</b><br/>%s"
+"<b>Asunto del correo electrónico:</b> %s<br/><br/><b>Cuerpo del correo electrónico:</b><br/"
+">%s"
 
 #. module: rma
 #: model:mail.template,body_html:rma.mail_template_rma_notification
@@ -70,8 +66,7 @@ msgid ""
 "        (${object.partner_id.parent_id.name})\n"
 "    % endif\n"
 "    <br/><br/>\n"
-"    Here is the RMA <strong>${object.name}</strong> from ${object.company_id."
-"name}.\n"
+"    Here is the RMA <strong>${object.name}</strong> from ${object.company_id.name}.\n"
 "    <br/><br/>\n"
 "    Do not hesitate to contact us if you have any question.\n"
 "</p>\n"
@@ -85,8 +80,7 @@ msgstr ""
 "        (${object.partner_id.parent_id.name})\n"
 "    % endif\n"
 "    <br/><br/>\n"
-"    Aquí tiene el RMA <strong>${object.name}</strong> Desde ${object."
-"company_id.name}.\n"
+"    Aquí tiene el RMA <strong>${object.name}</strong> Desde ${object.company_id.name}.\n"
 "    <br/><br/>\n"
 "    No dude en ponerse en contacto con nosotros si tiene alguna pregunta.\n"
 "</p>\n"
@@ -163,12 +157,9 @@ msgstr ""
 
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.portal_rma_page
-msgid ""
-"<i class=\"fa fa-download\" role=\"img\" aria-label=\"Download\" title="
-"\"Download\"/>"
+msgid "<i class=\"fa fa-download\" role=\"img\" aria-label=\"Download\" title=\"Download\"/>"
 msgstr ""
-"<i class=\"fa fa-download\" role=\"img\" aria-label=\"Download\" title="
-"\"Descargar\"/>"
+"<i class=\"fa fa-download\" role=\"img\" aria-label=\"Download\" title=\"Descargar\"/>"
 
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.portal_rma_page
@@ -187,63 +178,63 @@ msgstr "<i class=\"fa fa-fw fa-clock-o\"/><b>Esperando Pago</b>"
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.portal_rma_page
 msgid ""
-"<i class=\"fa fa-pencil-square-o mr-1\" role=\"img\" aria-label=\"Download\" "
-"title=\"Download\"/>"
-msgstr ""
-"<i class=\"fa fa-pencil-square-o mr-1\" role=\"img\" aria-label=\"Download\" "
-"title=\"Descargar\"/>"
-
-#. module: rma
-#: model_terms:ir.ui.view,arch_db:rma.portal_rma_page
-msgid ""
-"<i class=\"fa fa-truck mr-1\" role=\"img\" aria-label=\"Download\" title="
+"<i class=\"fa fa-pencil-square-o mr-1\" role=\"img\" aria-label=\"Download\" title="
 "\"Download\"/>"
 msgstr ""
-"<i class=\"fa fa-truck mr-1\" role=\"img\" aria-label=\"Download\" title="
+"<i class=\"fa fa-pencil-square-o mr-1\" role=\"img\" aria-label=\"Download\" title="
 "\"Descargar\"/>"
 
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.portal_rma_page
 msgid ""
-"<span class=\"badge badge-danger label-text-align\"><i class=\"fa fa-fw fa-"
-"times\"/> Cancelled</span>"
+"<i class=\"fa fa-truck mr-1\" role=\"img\" aria-label=\"Download\" title=\"Download\"/>"
 msgstr ""
-"<span class=\"badge badge-danger label-text-align\"><i class=\"fa fa-fw fa-"
-"times\"/>Cancelado</span>"
+"<i class=\"fa fa-truck mr-1\" role=\"img\" aria-label=\"Download\" title=\"Descargar\"/>"
 
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.portal_rma_page
 msgid ""
-"<span class=\"badge badge-info label-text-align\"><i class=\"fa fa-fw fa-"
-"clock-o\"/> Preparation</span>"
+"<span class=\"badge badge-danger label-text-align\"><i class=\"fa fa-fw fa-times\"/> "
+"Cancelled</span>"
 msgstr ""
-"<span class=\"badge badge-info label-text-align\"><i class=\"fa fa-fw fa-"
-"clock-o\"/>Preparación</span>"
+"<span class=\"badge badge-danger label-text-align\"><i class=\"fa fa-fw fa-times\"/"
+">Cancelado</span>"
 
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.portal_rma_page
 msgid ""
-"<span class=\"badge badge-success label-text-align\"><i class=\"fa fa-fw fa-"
-"truck\"/> Shipped</span>"
+"<span class=\"badge badge-info label-text-align\"><i class=\"fa fa-fw fa-clock-o\"/> "
+"Preparation</span>"
 msgstr ""
-"<span class=\"badge badge-success label-text-align\"><i class=\"fa fa-fw fa-"
-"truck\"/> Enviado</span>"
+"<span class=\"badge badge-info label-text-align\"><i class=\"fa fa-fw fa-clock-o\"/"
+">Preparación</span>"
 
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.portal_rma_page
 msgid ""
-"<span class=\"badge badge-warning label-text-align\"><i class=\"fa fa-fw fa-"
-"clock-o\"/> Partially Available</span>"
+"<span class=\"badge badge-success label-text-align\"><i class=\"fa fa-fw fa-truck\"/> "
+"Shipped</span>"
 msgstr ""
-"<span class=\"badge badge-warning label-text-align\"><i class=\"fa fa-fw fa-"
-"clock-o\"/>Disponible parcialmente</span>"
+"<span class=\"badge badge-success label-text-align\"><i class=\"fa fa-fw fa-truck\"/> "
+"Enviado</span>"
+
+#. module: rma
+#: model_terms:ir.ui.view,arch_db:rma.portal_rma_page
+msgid ""
+"<span class=\"badge badge-warning label-text-align\"><i class=\"fa fa-fw fa-clock-o\"/> "
+"Partially Available</span>"
+msgstr ""
+"<span class=\"badge badge-warning label-text-align\"><i class=\"fa fa-fw fa-clock-o\"/"
+">Disponible parcialmente</span>"
 
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.res_config_settings_view_form
 msgid ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" groups=\"base.group_multi_company\"/>"
+"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-specific.\" "
+"groups=\"base.group_multi_company\"/>"
 msgstr ""
+"<span class=\"fa fa-lg fa-building-o\" title=\"Valores específicos por compañía.\" groups="
+"\"base.group_multi_company\"/>"
 
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.portal_rma_page
@@ -369,11 +360,11 @@ msgstr "<strong>Estado:</strong>"
 #. module: rma
 #: model:ir.model.fields,help:rma.field_rma_team__alias_defaults
 msgid ""
-"A Python dictionary that will be evaluated to provide default values when "
-"creating new records for this alias."
+"A Python dictionary that will be evaluated to provide default values when creating new "
+"records for this alias."
 msgstr ""
-"Diccionario Python a evaluar para proporcionar valores por defecto cuando un "
-"nuevo registro se cree para este seudónimo."
+"Diccionario Python a evaluar para proporcionar valores por defecto cuando un nuevo "
+"registro se cree para este seudónimo."
 
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.rma_team_view_form
@@ -762,9 +753,7 @@ msgstr "Enviar correo al cliente una vez se recepcionen los productos del RMA."
 #: model:ir.model.fields,help:rma.field_res_company__rma_mail_draft_confirmation_template_id
 #: model:ir.model.fields,help:rma.field_res_config_settings__rma_mail_draft_confirmation_template_id
 msgid "Email sent to the customer when they place an RMA from the portal"
-msgstr ""
-"Enviar correo de confirmación al cliente una vez se tramite el RMA desde el "
-"portal"
+msgstr "Enviar correo de confirmación al cliente una vez se tramite el RMA desde el portal"
 
 #. module: rma
 #: code:addons/rma/wizard/rma_split.py:0
@@ -841,6 +830,18 @@ msgid "Group By"
 msgstr "Agrupar por"
 
 #. module: rma
+#: model:ir.model.fields,field_description:rma.field_res_company__rma_return_grouping
+#: model:ir.model.fields,field_description:rma.field_res_config_settings__rma_return_grouping
+#: model:ir.model.fields,field_description:rma.field_rma_delivery_wizard__rma_return_grouping
+msgid "Group RMA returns by customer address and warehouse"
+msgstr "Agrupar las devoluciones de RMA a cliente por dirección de envío y almacén"
+
+#. module: rma
+#: model_terms:ir.ui.view,arch_db:rma.res_config_settings_view_form
+msgid "Group RMA returns by customer and warehouse."
+msgstr "Agrupar las devoluciones de RMA a cliente por dirección de envío y almacén"
+
+#. module: rma
 #: model:ir.model.fields,field_description:rma.field_rma__id
 #: model:ir.model.fields,field_description:rma.field_rma_delivery_wizard__id
 #: model:ir.model.fields,field_description:rma.field_rma_finalization__id
@@ -855,11 +856,11 @@ msgstr ""
 #. module: rma
 #: model:ir.model.fields,help:rma.field_rma_team__alias_parent_thread_id
 msgid ""
-"ID of the parent record holding the alias (example: project holding the task "
-"creation alias)"
+"ID of the parent record holding the alias (example: project holding the task creation "
+"alias)"
 msgstr ""
-"ID del registro padre que tiene el seudónimo. (ejemplo: el proyecto que "
-"contiene el seudónimo para la creación de tareas)"
+"ID del registro padre que tiene el seudónimo. (ejemplo: el proyecto que contiene el "
+"seudónimo para la creación de tareas)"
 
 #. module: rma
 #: model:ir.model.fields,field_description:rma.field_rma__activity_exception_icon
@@ -890,11 +891,10 @@ msgstr "Si se encuentra marcado, algunos mensajes tienen error de envío."
 #. module: rma
 #: model:ir.model.fields,help:rma.field_rma_team__active
 msgid ""
-"If the active field is set to false, it will allow you to hide the RMA Team "
-"without removing it."
+"If the active field is set to false, it will allow you to hide the RMA Team without "
+"removing it."
 msgstr ""
-"Si el campo activo se establece a Falso, permitirá ocultar El equipo de RMA "
-"sin eliminarlo."
+"Si el campo activo se establece a Falso, permitirá ocultar El equipo de RMA sin eliminarlo."
 
 #. module: rma
 #: code:addons/rma/models/rma.py:0
@@ -998,19 +998,17 @@ msgstr "Adjuntos principales"
 #. module: rma
 #: model_terms:ir.actions.act_window,help:rma.action_rma_finalization
 msgid ""
-"Manage RMA finalization reasons to better classify them for tracking and "
-"analysis purposes."
+"Manage RMA finalization reasons to better classify them for tracking and analysis purposes."
 msgstr ""
-"Adminitrar motivos de finalización de RMA para una mejor clasificación de "
-"estos para su seguimiento análisis posterior."
+"Adminitrar motivos de finalización de RMA para una mejor clasificación de estos para su "
+"seguimiento análisis posterior."
 
 #. module: rma
 #: model_terms:ir.actions.act_window,help:rma.action_rma_tag
-msgid ""
-"Manage RMA tags to better classify them for tracking and analysis purposes."
+msgid "Manage RMA tags to better classify them for tracking and analysis purposes."
 msgstr ""
-"Administrar etiquetas de RMA para clasificarlos de modo que mejore el "
-"seguimiento y análisis de los mismos."
+"Administrar etiquetas de RMA para clasificarlos de modo que mejore el seguimiento y "
+"análisis de los mismos."
 
 #. module: rma
 #: model:ir.module.category,description:rma.rma_module_category
@@ -1119,13 +1117,12 @@ msgstr "Número de mensajes no leidos"
 #. module: rma
 #: model:ir.model.fields,help:rma.field_rma_team__alias_force_thread_id
 msgid ""
-"Optional ID of a thread (record) to which all incoming messages will be "
-"attached, even if they did not reply to it. If set, this will disable the "
-"creation of new records completely."
+"Optional ID of a thread (record) to which all incoming messages will be attached, even if "
+"they did not reply to it. If set, this will disable the creation of new records completely."
 msgstr ""
-"Id. opcional de un hilo (registro) al que todos los mensajes entrantes serán "
-"adjuntados, incluso si no fueron respuestas del mismo. Si se establece, se "
-"deshabilitará completamente la creación de nuevos registros."
+"Id. opcional de un hilo (registro) al que todos los mensajes entrantes serán adjuntados, "
+"incluso si no fueron respuestas del mismo. Si se establece, se deshabilitará completamente "
+"la creación de nuevos registros."
 
 #. module: rma
 #: model:ir.ui.menu,name:rma.rma_orders_menu
@@ -1165,12 +1162,11 @@ msgstr "ID del hilo del registro padre"
 #. module: rma
 #: model:ir.model.fields,help:rma.field_rma_team__alias_parent_model_id
 msgid ""
-"Parent model holding the alias. The model holding the alias reference is not "
-"necessarily the model given by alias_model_id (example: project "
-"(parent_model) and task (model))"
+"Parent model holding the alias. The model holding the alias reference is not necessarily "
+"the model given by alias_model_id (example: project (parent_model) and task (model))"
 msgstr ""
-"Modelo padre que contiene el alias. El modelo que contiene la referencia "
-"alias no es necesariamente el modelo dado por alias_model_id"
+"Modelo padre que contiene el alias. El modelo que contiene la referencia alias no es "
+"necesariamente el modelo dado por alias_model_id"
 
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.rma_view_search
@@ -1183,15 +1179,13 @@ msgid ""
 "Policy to post a message on the document using the mailgateway.\n"
 "- everyone: everyone can post\n"
 "- partners: only authenticated partners\n"
-"- followers: only followers of the related document or members of following "
-"channels\n"
+"- followers: only followers of the related document or members of following channels\n"
 msgstr ""
-"Política para publicar un mensaje en el documento utilizando el servidor de "
-"correo.\n"
+"Política para publicar un mensaje en el documento utilizando el servidor de correo.\n"
 "- todo el mundo: todos pueden publicar\n"
 "- socios: sólo socios autenticados\n"
-"- seguidores: sólo seguidores del documento relacionado o miembros de los "
-"siguientes canales\n"
+"- seguidores: sólo seguidores del documento relacionado o miembros de los siguientes "
+"canales\n"
 
 #. module: rma
 #: model:ir.model.fields,field_description:rma.field_rma__access_url
@@ -1250,12 +1244,8 @@ msgstr "Cantidad a extraer"
 #. module: rma
 #: code:addons/rma/models/rma.py:0
 #, python-format
-msgid ""
-"Quantity to extract cannot be greater than remaining delivery quantity (%s "
-"%s)"
-msgstr ""
-"La cantidad a extraer no puede ser mayor que la cantidad de entrega "
-"restante(%s %s)"
+msgid "Quantity to extract cannot be greater than remaining delivery quantity (%s %s)"
+msgstr "La cantidad a extraer no puede ser mayor que la cantidad de entrega restante(%s %s)"
 
 #. module: rma
 #: model:ir.model.fields,help:rma.field_rma_split_wizard__product_uom_qty
@@ -1263,13 +1253,11 @@ msgid "Quantity to extract to a new RMA."
 msgstr "Cantidad a extraer en nuevo RMA."
 
 #. module: rma
-#: model:ir.actions.act_window,name:rma.rma_action
-#: model:ir.model,name:rma.model_rma
+#: model:ir.actions.act_window,name:rma.rma_action model:ir.model,name:rma.model_rma
 #: model:ir.model.fields,field_description:rma.field_account_move_line__rma_id
 #: model:ir.model.fields,field_description:rma.field_rma_split_wizard__rma_id
 #: model:ir.model.fields,field_description:rma.field_stock_warehouse__rma
-#: model:ir.module.category,name:rma.rma_module_category
-#: model:ir.ui.menu,name:rma.rma_menu
+#: model:ir.module.category,name:rma.rma_module_category model:ir.ui.menu,name:rma.rma_menu
 #: model_terms:ir.ui.view,arch_db:rma.view_partner_form
 #: model_terms:ir.ui.view,arch_db:rma.view_picking_form
 msgid "RMA"
@@ -1401,8 +1389,7 @@ msgid "RMA Tag"
 msgstr "Etiqueta RMA"
 
 #. module: rma
-#: model:ir.actions.act_window,name:rma.action_rma_tag
-#: model:ir.model,name:rma.model_rma_tag
+#: model:ir.actions.act_window,name:rma.action_rma_tag model:ir.model,name:rma.model_rma_tag
 #: model:ir.ui.menu,name:rma.rma_configuration_rma_tag_menu
 #: model_terms:ir.ui.view,arch_db:rma.rma_tag_view_search
 #: model_terms:ir.ui.view,arch_db:rma.view_rma_tag_list
@@ -1452,8 +1439,7 @@ msgstr "RMAs que originaron esta orden"
 #. module: rma
 #: model:ir.model.fields,help:rma.field_stock_warehouse__rma
 msgid "RMA related products can be stored in this warehouse."
-msgstr ""
-"Productos relacionados con el RMA pueden ser guardados en este almacén."
+msgstr "Productos relacionados con el RMA pueden ser guardados en este almacén."
 
 #. module: rma
 #: model:ir.model,name:rma.model_rma_operation
@@ -1584,27 +1570,25 @@ msgstr "Reemplazado"
 #: code:addons/rma/models/rma.py:0
 #, python-format
 msgid ""
-"Replacement: Move <a href=\"#\" data-oe-model=\"stock.move\" data-oe-id=\"%d"
-"\">%s</a> (Picking <a href=\"#\" data-oe-model=\"stock.picking\" data-oe-id="
-"\"%d\">%s</a>) has been created."
+"Replacement: Move <a href=\"#\" data-oe-model=\"stock.move\" data-oe-id=\"%d\">%s</a> "
+"(Picking <a href=\"#\" data-oe-model=\"stock.picking\" data-oe-id=\"%d\">%s</a>) has been "
+"created."
 msgstr ""
-"Reemplazo: El movimiento <a href=\"#\" data-oe-model=\"stock.move\" data-oe-"
-"id=\"%d\">%s</a> (Orden de entrega <a href=\"#\" data-oe-model=\"stock."
-"picking\" data-oe-id=\"%d\">%s</a>) ha sido creado."
+"Reemplazo: El movimiento <a href=\"#\" data-oe-model=\"stock.move\" data-oe-id=\"%d\">%s</"
+"a> (Orden de entrega <a href=\"#\" data-oe-model=\"stock.picking\" data-oe-id=\"%d\">%s</"
+"a>) ha sido creado."
 
 #. module: rma
 #: code:addons/rma/models/rma.py:0
 #, python-format
 msgid ""
-"Replacement:<br/>Product <a href=\"#\" data-oe-model=\"product.product\" "
-"data-oe-id=\"%d\">%s</a><br/>Quantity %f %s<br/>This replacement did not "
-"create a new move, but one of the previously created moves was updated with "
-"this data."
+"Replacement:<br/>Product <a href=\"#\" data-oe-model=\"product.product\" data-oe-id=\"%d\">"
+"%s</a><br/>Quantity %f %s<br/>This replacement did not create a new move, but one of the "
+"previously created moves was updated with this data."
 msgstr ""
-"Reemplazo:<br/>Producto <a href=\"#\" data-oe-model=\"product.product\" data-"
-"oe-id=\"%d\">%s</a><br/>Cantidad %f %s<br/>El reemplazo realizado no creó un "
-"movimiento nuevo, pero uno de los movimientos creados anteriormente fué "
-"actualizado con estos datos."
+"Reemplazo:<br/>Producto <a href=\"#\" data-oe-model=\"product.product\" data-oe-id=\"%d\">"
+"%s</a><br/>Cantidad %f %s<br/>El reemplazo realizado no creó un movimiento nuevo, pero uno "
+"de los movimientos creados anteriormente fué actualizado con estos datos."
 
 #. module: rma
 #: model:ir.ui.menu,name:rma.rma_reporting_menu
@@ -1649,11 +1633,11 @@ msgstr "Devolver al cliente"
 #: code:addons/rma/models/rma.py:0
 #, python-format
 msgid ""
-"Return: <a href=\"#\" data-oe-model=\"stock.picking\" data-oe-id=\"%d\">%s</"
-"a> has been created."
+"Return: <a href=\"#\" data-oe-model=\"stock.picking\" data-oe-id=\"%d\">%s</a> has been "
+"created."
 msgstr ""
-"Devolución: La orden de entrega <a href=\"#\" data-oe-model=\"stock.picking"
-"\" data-oe-id=\"%d\">%s</a> ha sido creada."
+"Devolución: La orden de entrega <a href=\"#\" data-oe-model=\"stock.picking\" data-oe-id="
+"\"%d\">%s</a> ha sido creada."
 
 #. module: rma
 #: model:ir.model.fields.selection,name:rma.selection__rma__state__returned
@@ -1790,12 +1774,10 @@ msgstr "Dividir RMA"
 #. module: rma
 #: code:addons/rma/models/rma.py:0
 #, python-format
-msgid ""
-"Split: <a href=\"#\" data-oe-model=\"rma\" data-oe-id=\"%d\">%s</a> has been "
-"created."
+msgid "Split: <a href=\"#\" data-oe-model=\"rma\" data-oe-id=\"%d\">%s</a> has been created."
 msgstr ""
-"División: El RMA <a href=\"#\" data-oe-model=\"rma\" data-oe-id=\"%d\">%s</"
-"a> ha sido creado."
+"División: El RMA <a href=\"#\" data-oe-model=\"rma\" data-oe-id=\"%d\">%s</a> ha sido "
+"creado."
 
 #. module: rma
 #: model:ir.model.fields,field_description:rma.field_rma__state
@@ -1804,8 +1786,7 @@ msgid "State"
 msgstr "Estado"
 
 #. module: rma
-#: code:addons/rma/controllers/main.py:0
-#: model_terms:ir.ui.view,arch_db:rma.portal_my_rmas
+#: code:addons/rma/controllers/main.py:0 model_terms:ir.ui.view,arch_db:rma.portal_my_rmas
 #, python-format
 msgid "Status"
 msgstr "Estado"
@@ -1877,46 +1858,44 @@ msgstr ""
 #. module: rma
 #: model:ir.model.fields,help:rma.field_rma_team__alias_model_id
 msgid ""
-"The model (Odoo Document Kind) to which this alias corresponds. Any incoming "
-"email that does not reply to an existing record will cause the creation of a "
-"new record of this model (e.g. a Project Task)"
+"The model (Odoo Document Kind) to which this alias corresponds. Any incoming email that "
+"does not reply to an existing record will cause the creation of a new record of this model "
+"(e.g. a Project Task)"
 msgstr ""
-"El modelo (Tipo de documento de Odoo) al que corresponde este seudónimo. "
-"Cualquier correo entrante que no sea respuesta a un registro existente, "
-"causará la creación de un nuevo registro de este modelo"
+"El modelo (Tipo de documento de Odoo) al que corresponde este seudónimo. Cualquier correo "
+"entrante que no sea respuesta a un registro existente, causará la creación de un nuevo "
+"registro de este modelo"
 
 #. module: rma
 #: model:ir.model.fields,help:rma.field_rma_team__alias_name
 msgid ""
-"The name of the email alias, e.g. 'jobs' if you want to catch emails for "
-"<jobs@example.odoo.com>"
+"The name of the email alias, e.g. 'jobs' if you want to catch emails for <jobs@example."
+"odoo.com>"
 msgstr ""
-"El nombre de este seudónimo de correo electrónico. Por ejemplo, \"trabajos"
-"\", si lo que quiere es obtener los correos para <trabajos@example.odoo.com>"
+"El nombre de este seudónimo de correo electrónico. Por ejemplo, \"trabajos\", si lo que "
+"quiere es obtener los correos para <trabajos@example.odoo.com>"
 
 #. module: rma
 #: model:ir.model.fields,help:rma.field_rma_team__alias_user_id
 msgid ""
-"The owner of records created upon receiving emails on this alias. If this "
-"field is not set the system will attempt to find the right owner based on "
-"the sender (From) address, or will use the Administrator account if no "
-"system user is found for that address."
+"The owner of records created upon receiving emails on this alias. If this field is not set "
+"the system will attempt to find the right owner based on the sender (From) address, or "
+"will use the Administrator account if no system user is found for that address."
 msgstr ""
-"El propietario de los registros creados al recibir correos electrónicos en "
-"este seudónimo. Si el campo no está establecido, el sistema tratará de "
-"encontrar el propietario adecuado basado en la dirección del emisor (De), o "
-"usará la cuenta de administrador si no se encuentra un usuario para esa "
-"dirección."
+"El propietario de los registros creados al recibir correos electrónicos en este seudónimo. "
+"Si el campo no está establecido, el sistema tratará de encontrar el propietario adecuado "
+"basado en la dirección del emisor (De), o usará la cuenta de administrador si no se "
+"encuentra un usuario para esa dirección."
 
 #. module: rma
 #: code:addons/rma/models/stock_move.py:0
 #, python-format
 msgid ""
-"The quantity done for the product '%s' must be equal to its initial demand "
-"because the stock move is linked to an RMA (%s)."
+"The quantity done for the product '%s' must be equal to its initial demand because the "
+"stock move is linked to an RMA (%s)."
 msgstr ""
-"La cantidad realizada para el producto '%s' debe ser igual a la demanda "
-"inicial porque el movimiento está enlazado a un RMA (%s)."
+"La cantidad realizada para el producto '%s' debe ser igual a la demanda inicial porque el "
+"movimiento está enlazado a un RMA (%s)."
 
 #. module: rma
 #: code:addons/rma/models/rma.py:0
@@ -1933,11 +1912,11 @@ msgstr "La etiqueta es visible en la vista de portal"
 #: code:addons/rma/models/account_move.py:0
 #, python-format
 msgid ""
-"There is at least one invoice lines whose quantity is less than the quantity "
-"specified in its linked RMA."
+"There is at least one invoice lines whose quantity is less than the quantity specified in "
+"its linked RMA."
 msgstr ""
-"Hay al menos una linea de factura que tiene una cantidad menor que la "
-"cantidad especificada en el RMA asociado."
+"Hay al menos una linea de factura que tiene una cantidad menor que la cantidad "
+"especificada en el RMA asociado."
 
 #. module: rma
 #: code:addons/rma/models/rma.py:0
@@ -2084,8 +2063,8 @@ msgstr ""
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.res_config_settings_view_form
 msgid ""
-"When customers themselves place an RMA from the portal, send an automatic "
-"notification acknowleging it."
+"When customers themselves place an RMA from the portal, send an automatic notification "
+"acknowleging it."
 msgstr ""
 
 #. module: rma
@@ -2102,22 +2081,19 @@ msgstr ""
 
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.res_config_settings_view_form
-msgid ""
-"When the RMA products are received, send an automatic information email."
+msgid "When the RMA products are received, send an automatic information email."
 msgstr ""
 
 #. module: rma
 #: model:ir.model.fields,help:rma.field_res_company__send_rma_receipt_confirmation
 #: model:ir.model.fields,help:rma.field_res_config_settings__send_rma_receipt_confirmation
-msgid ""
-"When the RMA receipt is confirmed, send a confirmation email to the customer."
+msgid "When the RMA receipt is confirmed, send a confirmation email to the customer."
 msgstr ""
 
 #. module: rma
 #: model:ir.model.fields,help:rma.field_res_company__send_rma_confirmation
 #: model:ir.model.fields,help:rma.field_res_config_settings__send_rma_confirmation
-msgid ""
-"When the delivery is confirmed, send a confirmation email to the customer."
+msgid "When the delivery is confirmed, send a confirmation email to the customer."
 msgstr ""
 
 #. module: rma
@@ -2130,11 +2106,9 @@ msgstr "No puede eliminar RMAs que no estén en estado borrador"
 #: code:addons/rma/wizard/stock_picking_return.py:0
 #, python-format
 msgid ""
-"You must specify the 'Customer' in the 'Stock Picking' from which RMAs will "
-"be created"
+"You must specify the 'Customer' in the 'Stock Picking' from which RMAs will be created"
 msgstr ""
-"Debe seleccionar el 'Cliente' en la 'Orden de Entrega' desde la cual los "
-"RMAs serán creados"
+"Debe seleccionar el 'Cliente' en la 'Orden de Entrega' desde la cual los RMAs serán creados"
 
 #. module: rma
 #: model:ir.actions.report,print_report_name:rma.report_rma_action
@@ -2143,10 +2117,8 @@ msgstr ""
 
 #. module: rma
 #: model:res.groups,comment:rma.rma_group_user_all
-msgid ""
-"the user will have access to all records of everyone in the RMA application."
-msgstr ""
-"El usuario tendrá acceso a todos los registros de RMA de todos lo usuarios."
+msgid "the user will have access to all records of everyone in the RMA application."
+msgstr "El usuario tendrá acceso a todos los registros de RMA de todos lo usuarios."
 
 #. module: rma
 #: model:res.groups,comment:rma.rma_group_user_own
@@ -2155,9 +2127,5 @@ msgstr "el usuario tendrá acceso solo a sus propios RMAs."
 
 #. module: rma
 #: model:res.groups,comment:rma.rma_group_manager
-msgid ""
-"the user will have an access to the RMA configuration as well as statistic "
-"reports."
-msgstr ""
-"El usuario tendrá acceso a la configuración de RMA y a los informes "
-"estadísticos."
+msgid "the user will have an access to the RMA configuration as well as statistic reports."
+msgstr "El usuario tendrá acceso a la configuración de RMA y a los informes estadísticos."

--- a/rma/i18n/rma.pot
+++ b/rma/i18n/rma.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-07 16:33+0000\n"
+"PO-Revision-Date: 2022-03-07 16:33+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -765,6 +767,18 @@ msgstr ""
 #. module: rma
 #: model_terms:ir.ui.view,arch_db:rma.rma_view_search
 msgid "Group By"
+msgstr ""
+
+#. module: rma
+#: model:ir.model.fields,field_description:rma.field_res_company__rma_return_grouping
+#: model:ir.model.fields,field_description:rma.field_res_config_settings__rma_return_grouping
+#: model:ir.model.fields,field_description:rma.field_rma_delivery_wizard__rma_return_grouping
+msgid "Group RMA returns by customer address and warehouse"
+msgstr ""
+
+#. module: rma
+#: model_terms:ir.ui.view,arch_db:rma.res_config_settings_view_form
+msgid "Group RMA returns by customer and warehouse."
 msgstr ""
 
 #. module: rma

--- a/rma/models/res_company.py
+++ b/rma/models/res_company.py
@@ -25,6 +25,9 @@ class Company(models.Model):
         except ValueError:
             return False
 
+    rma_return_grouping = fields.Boolean(
+        string="Group RMA returns by customer address and warehouse", default=True,
+    )
     send_rma_confirmation = fields.Boolean(
         string="Send RMA Confirmation",
         help="When the delivery is confirmed, send a confirmation email "

--- a/rma/models/res_config_settings.py
+++ b/rma/models/res_config_settings.py
@@ -11,6 +11,9 @@ class ResConfigSettings(models.TransientModel):
         help="Allow to finish an RMA without returning back a product or refunding",
         implied_group="rma.group_rma_manual_finalization",
     )
+    rma_return_grouping = fields.Boolean(
+        related="company_id.rma_return_grouping", readonly=False,
+    )
     send_rma_confirmation = fields.Boolean(
         related="company_id.send_rma_confirmation", readonly=False,
     )

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -1050,6 +1050,9 @@ class Rma(models.Model):
     # Returning business methods
     def create_return(self, scheduled_date, qty=None, uom=None):
         """Intended to be invoked by the delivery wizard"""
+        group_returns = self.env.company.rma_return_grouping
+        if "rma_return_grouping" in self.env.context:
+            group_returns = self.env.context.get("rma_return_grouping")
         self._ensure_can_be_returned()
         self._ensure_qty_to_return(qty, uom)
         group_dict = {}
@@ -1062,7 +1065,11 @@ class Rma(models.Model):
             )
             group_dict.setdefault(key, self.env["rma"])
             group_dict[key] |= record
-        for rmas in group_dict.values():
+        if group_returns:
+            grouped_rmas = group_dict.values()
+        else:
+            grouped_rmas = rmas_to_return
+        for rmas in grouped_rmas:
             origin = ", ".join(rmas.mapped("name"))
             rma_out_type = rmas[0].warehouse_id.rma_out_type_id
             picking_form = Form(

--- a/rma/readme/CONFIGURE.rst
+++ b/rma/readme/CONFIGURE.rst
@@ -11,3 +11,11 @@ If you want to manually finish RMAs, you need to:
 
 #. Go to *Settings > Inventory*.
 #. Set *Finish RMAs manually* checkbox on.
+
+By default, returns to customer are grouped by shipping address, warehouse and company.
+If you want to avoid this grouping you can:
+
+#. Go to *Settings > Inventory*.
+#. Set *Group RMA returns by customer address and warehouse* checkbox off.
+
+The users will still be able to group those pickings from the wizard.

--- a/rma/static/description/index.html
+++ b/rma/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Return Merchandise Authorization Management</title>
 <style type="text/css">
 
@@ -406,6 +406,13 @@ one.</li>
 <li>Go to <em>Settings &gt; Inventory</em>.</li>
 <li>Set <em>Finish RMAs manually</em> checkbox on.</li>
 </ol>
+<p>By default, returns to customer are grouped by shipping address, warehouse and company.
+If you want to avoid this grouping you can:</p>
+<ol class="arabic simple">
+<li>Go to <em>Settings &gt; Inventory</em>.</li>
+<li>Set <em>Group RMA returns by customer address and warehouse</em> checkbox off.</li>
+</ol>
+<p>The users will still be able to group those pickings from the wizard.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id2">Usage</a></h1>

--- a/rma/views/res_config_settings_views.xml
+++ b/rma/views/res_config_settings_views.xml
@@ -23,6 +23,22 @@
                         </div>
                     </div>
                 </div>
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="rma_return_grouping" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="rma_return_grouping" />
+                        <span
+                            class="fa fa-lg fa-building-o"
+                            title="Values set here are company-specific."
+                            groups="base.group_multi_company"
+                        />
+                        <div class="text-muted">
+                            Group RMA returns by customer and warehouse.
+                        </div>
+                    </div>
+                </div>
                 <div
                     class="col-12 col-lg-6 o_setting_box"
                     title="Send automatic RMA info to customer"

--- a/rma/wizard/rma_delivery.py
+++ b/rma/wizard/rma_delivery.py
@@ -26,6 +26,10 @@ class RmaReDeliveryWizard(models.TransientModel):
     warehouse_id = fields.Many2one(
         comodel_name="stock.warehouse", string="Warehouse", required=True,
     )
+    rma_return_grouping = fields.Boolean(
+        string="Group RMA returns by customer address and warehouse",
+        default=lambda self: self.env.company.rma_return_grouping,
+    )
 
     @api.constrains("product_uom_qty")
     def _check_product_uom_qty(self):
@@ -87,4 +91,6 @@ class RmaReDeliveryWizard(models.TransientModel):
             qty = uom = None
             if self.rma_count == 1:
                 qty, uom = self.product_uom_qty, self.product_uom
-            rma.create_return(self.scheduled_date, qty, uom)
+            rma.with_context(
+                rma_return_grouping=self.rma_return_grouping
+            ).create_return(self.scheduled_date, qty, uom)

--- a/rma/wizard/rma_delivery_views.xml
+++ b/rma/wizard/rma_delivery_views.xml
@@ -14,6 +14,10 @@
                             name="warehouse_id"
                             attrs="{'invisible': [('type', '!=', 'replace')]}"
                         />
+                        <field
+                            name="rma_return_grouping"
+                            attrs="{'invisible': ['|', ('type', '=', 'replace'), ('rma_count', '=', 1)]}"
+                        />
                     </group>
                     <group>
                         <field


### PR DESCRIPTION
By default, returns to customer are grouped by shipping address, warehouse and company.
If you want to avoid this grouping you can:

- Go to *Settings > Inventory*.
- Set *Group RMA returns by customer address and warehouse* checkbox off.

The users will still be able to group those pickings from the wizard.

cc @Tecnativa TT34806

please review @ernestotejeda @pedrobaeza 