### PR TITLE
[13.0][FIX] rma: name column width in tree view

### DIFF
--- a/rma/views/rma_views.xml
+++ b/rma/views/rma_views.xml
@@ -89,7 +89,7 @@
                 decoration-bf="state == 'draft' and product_id == False"
                 decoration-danger="deadline and (deadline &lt; current_date)"
             >
-                <field name="name" />
+                <field name="name" width="100px" />
                 <field name="origin" />
                 <field name="user_id" />
                 <field name="partner_id" />


### PR DESCRIPTION
In the tree view, the RMA code (`name` field) tends to lose in the
column width share. The result is will be the trimming of the reference
with ellipsis (...).

As this is very relevant information, we want to ensure a minimum width
for such reference.

cc @Tecnativa TT35107

ping @pedrobaeza @victoralmau 