### PR TITLE
[14.0][FIX] rma + rma_sale: Allow to create an RMA to a user  with access_token to sale order (no user created).

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -623,6 +623,10 @@ class Rma(models.Model):
             "context": ctx,
         }
 
+    def _add_message_subscribe_partner(self):
+        if self.partner_id not in self.message_partner_ids:
+            self.message_subscribe([self.partner_id.id])
+
     def action_confirm(self):
         """Invoked when 'Confirm' button in rma form view is clicked."""
         self.ensure_one()
@@ -633,8 +637,7 @@ class Rma(models.Model):
             else:
                 reception_move = self._create_receptions_from_product()
             self.write({"reception_move_id": reception_move.id, "state": "confirmed"})
-            if self.partner_id not in self.message_partner_ids:
-                self.message_subscribe([self.partner_id.id])
+            self._add_message_subscribe_partner()
             self._send_confirmation_email()
 
     def action_refund(self):

--- a/rma_sale/views/sale_portal_template.xml
+++ b/rma_sale/views/sale_portal_template.xml
@@ -245,15 +245,39 @@
     >
         <xpath expr="//div[@id='introduction']/h2[hasclass('my-0')]" position="inside">
             <span t-if="sale_order.rma_count" class="float-right">
-                <a
-                    role="button"
-                    t-attf-href="/my/rmas?sale_id=#{sale_order.id}"
-                    class="btn btn-sm btn-secondary"
-                >
-                    <span class="fa fa-reply" role="img" aria-label="RMA" title="RMA" />
-                    <span t-esc="sale_order.rma_count" />
-                    <span>RMA</span>
-                </a>
+                <t t-if="not user_has_group_portal_or_public">
+                    <a
+                        role="button"
+                        t-attf-href="/my/rmas?sale_id=#{sale_order.id}"
+                        class="btn btn-sm btn-secondary"
+                    >
+                        <span
+                            class="fa fa-reply"
+                            role="img"
+                            aria-label="RMA"
+                            title="RMA"
+                        />
+                        <span t-esc="sale_order.rma_count" />
+                        <span>RMA</span>
+                    </a>
+                </t>
+                <t t-if="user_has_group_portal_or_public">
+                    <t t-foreach="sale_order.rma_ids.sudo()" t-as="rma">
+                        <a
+                            role="button"
+                            t-attf-href="#{rma._get_share_url()}"
+                            class="btn btn-sm btn-secondary"
+                        >
+                            <span
+                                class="fa fa-reply"
+                                role="img"
+                                aria-label="RMA"
+                                title="RMA"
+                            />
+                            <span t-esc="rma.name" />
+                        </a>
+                    </t>
+                </t>
             </span>
         </xpath>
     </template>

--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -1,7 +1,8 @@
 # Copyright 2020 Tecnativa - Ernesto Tejeda
+# Copyright 2022 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
+from odoo import SUPERUSER_ID, _, api, fields, models
 
 
 class SaleOrderRmaWizard(models.TransientModel):
@@ -46,11 +47,22 @@ class SaleOrderRmaWizard(models.TransientModel):
         help="Values coming from portal RMA request form custom fields",
     )
 
-    def create_rma(self, from_portal=None):
+    def create_rma(self, from_portal=False):
         self.ensure_one()
+        user_has_group_portal = self.env.user.has_group(
+            "base.group_portal"
+        ) or self.env.user.has_group("base.group_public")
         lines = self.line_ids.filtered(lambda r: r.quantity > 0.0)
         val_list = [line._prepare_rma_values() for line in lines]
-        rma = self.env["rma"].create(val_list)
+        rma_model = self.env["rma"]
+        rma_model = (
+            self.env["rma"].with_user(SUPERUSER_ID)
+            if user_has_group_portal
+            else self.env["rma"]
+        )
+        rma = rma_model.create(val_list)
+        if from_portal:
+            rma._add_message_subscribe_partner()
         # post messages
         msg_list = [
             '<a href="#" data-oe-model="rma" data-oe-id="%d">%s</a>' % (r.id, r.name)


### PR DESCRIPTION
Changes:
- Allow to create an RMA to a user  with `access_token` to sale order (no user created).
- Show RMA's list (with share url) to a user with access_token to sale order (no user created).

Please @chienandalu and @ernestotejeda can you review it?

@Tecnativa