### PR TITLE
[13.0][FIX] rma + rma_sale: Allow to create an RMA to a user with access_token to sale order (no user created).

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -594,6 +594,10 @@ class Rma(models.Model):
             "context": ctx,
         }
 
+    def _add_message_subscribe_partner(self):
+        if self.partner_id and self.partner_id not in self.message_partner_ids:
+            self.message_subscribe([self.partner_id.id])
+
     def action_confirm(self):
         """Invoked when 'Confirm' button in rma form view is clicked."""
         self.ensure_one()
@@ -604,8 +608,7 @@ class Rma(models.Model):
             else:
                 reception_move = self._create_receptions_from_product()
             self.write({"reception_move_id": reception_move.id, "state": "confirmed"})
-            if self.partner_id not in self.message_partner_ids:
-                self.message_subscribe([self.partner_id.id])
+            self._add_message_subscribe_partner()
             self._send_confirmation_email()
 
     def action_refund(self):

--- a/rma_sale/views/sale_portal_template.xml
+++ b/rma_sale/views/sale_portal_template.xml
@@ -4,7 +4,7 @@
         <form
             id="form-request-rma"
             method="POST"
-            t-attf-action="/my/orders/#{sale_order.id}/requestrma?access_token=#{sale_order.access_token}"
+            t-attf-action="/my/orders/#{sale_order.id}/requestrma?{{ keep_query() }}"
             t-att-class="not single_page_mode and 'modal-content' or 'col-12'"
         >
             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" />


### PR DESCRIPTION
Changes:
- Allow to create an RMA to a user  with `access_token` to sale order (no user created).
- Show RMA's list (with share url) to a user with access_token to sale order (no user created).

Please @chienandalu and @ernestotejeda can you review it?

@Tecnativa