### PR TITLE
[13.0][FIX] rma: Avoid set invoice_payment_term_id from partner default value in refund.

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -1008,6 +1008,8 @@ class Rma(models.Model):
         """
         self.ensure_one()
         invoice_form.partner_id = self.partner_invoice_id
+        # Avoid set partner default value
+        invoice_form.invoice_payment_term_id = self.env["account.payment.term"]
 
     def _prepare_refund_line(self, line_form):
         """ Hook method for preparing a refund line Form.

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -39,6 +39,9 @@ class TestRma(SavepointCase):
             {
                 "name": "Partner test",
                 "property_account_receivable_id": cls.account_receiv.id,
+                "property_payment_term_id": cls.env.ref(
+                    "account.account_payment_term_30days"
+                ).id,
             }
         )
         cls.partner_invoice = cls.res_partner.create(
@@ -277,6 +280,7 @@ class TestRmaCase(TestRma):
         rma.action_refund()
         self.assertEqual(rma.refund_id.type, "out_refund")
         self.assertEqual(rma.refund_id.state, "draft")
+        self.assertFalse(rma.refund_id.invoice_payment_term_id)
         self.assertEqual(rma.refund_line_id.product_id, rma.product_id)
         self.assertEqual(rma.refund_line_id.quantity, 10)
         self.assertEqual(rma.refund_line_id.product_uom_id, rma.product_uom)


### PR DESCRIPTION
Changes done:
- [x] Avoid set `invoice_payment_term_id` from partner default value in refund.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT37690