### PR TITLE
[13.0][FIX] rma_sale: Apply the right taxes from sales order line to refund (or keep line without taxes).

### DIFF
--- a/rma_sale/models/rma.py
+++ b/rma_sale/models/rma.py
@@ -105,3 +105,9 @@ class Rma(models.Model):
         if line:
             line_form.discount = line.discount
             line_form.sequence = line.sequence
+            # remove all auto-set taxes (in case order line has not taxes)
+            for tax in line_form.tax_ids:
+                line_form.tax_ids.remove(tax.id)
+            # apply the right taxes
+            for tax in line.tax_id:
+                line_form.tax_ids.add(tax)

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -82,6 +82,7 @@ class TestRmaSale(SavepointCase):
         rma.reception_move_id.picking_id.action_done()
         rma.action_refund()
         self.assertEqual(rma.refund_id.user_id, user)
+        self.assertEqual(rma.refund_line_id.tax_ids, rma.sale_line_id.tax_id)
 
     def test_create_recurrent_rma(self):
         """An RMA of a product that had an RMA in the past should be possible"""


### PR DESCRIPTION
Apply the right taxes from sales order line to refund (or keep line without taxes).

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa