### PR TITLE
[13.0][FIX] rma_sale: Misc changes

### DIFF
--- a/rma_sale/models/rma.py
+++ b/rma_sale/models/rma.py
@@ -48,7 +48,7 @@ class Rma(models.Model):
             if rec.order_id:
                 order_move = rec.order_id.order_line.mapped("move_ids")
                 rec.allowed_move_ids = order_move.filtered(
-                    lambda r: r.picking_id == self.picking_id
+                    lambda r: r.picking_id == self.picking_id and r.state == "done"
                 ).ids
             else:
                 rec.allowed_move_ids = self.picking_id.move_lines.ids

--- a/rma_sale/models/rma.py
+++ b/rma_sale/models/rma.py
@@ -35,9 +35,9 @@ class Rma(models.Model):
     def _compute_allowed_picking_ids(self):
         domain = [("state", "=", "done"), ("picking_type_id.code", "=", "outgoing")]
         for rec in self:
-            # if rec.partner_id:
-            commercial_partner = rec.partner_id.commercial_partner_id
-            domain.append(("partner_id", "child_of", commercial_partner.id))
+            if rec.partner_id:
+                commercial_partner = rec.partner_id.commercial_partner_id
+                domain.append(("partner_id", "child_of", commercial_partner.id))
             if rec.order_id:
                 domain.append(("sale_id", "=", rec.order_id.id))
             rec.allowed_picking_ids = self.env["stock.picking"].search(domain)

--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -152,6 +152,7 @@ class SaleOrderLineRmaWizard(models.TransientModel):
                         r.sale_line_id == record.sale_line_id
                         and r.sale_line_id.product_id == record.product_id
                         and r.sale_line_id.order_id == record.order_id
+                        and r.state == "done"
                     )
                 )
             else:
@@ -169,7 +170,9 @@ class SaleOrderLineRmaWizard(models.TransientModel):
             line = record.order_id.order_line.filtered(
                 lambda r: r.product_id == record.product_id
             )
-            record.allowed_picking_ids = line.mapped("move_ids.picking_id")
+            record.allowed_picking_ids = line.mapped("move_ids.picking_id").filtered(
+                lambda x: x.state == "done"
+            )
 
     def _prepare_rma_values(self):
         self.ensure_one()

--- a/rma_sale/wizard/sale_order_rma_wizard_views.xml
+++ b/rma_sale/wizard/sale_order_rma_wizard_views.xml
@@ -25,7 +25,11 @@
                                 options="{'no_create': True}"
                             />
                             <field name="allowed_picking_ids" invisible="1" />
-                            <field name="picking_id" options="{'no_create': True}" />
+                            <field
+                                name="picking_id"
+                                options="{'no_create': True}"
+                                required="1"
+                            />
                             <field name="operation_id" />
                         </tree>
                     </field>


### PR DESCRIPTION
Changes done:
- [x] Prevent warning log in domain ("partner_id", "child_of", False) in partner if it's not set yet (Fixed in v14: https://github.com/OCA/rma/commit/0d98089699b39911f0246ce6a7a86d3a290a7a1d)
- [x] Filter done pickings and done moves
- [x] Set picking_id field to required in wizard to avoid creating rma if nothing has been delivered yet (related to https://github.com/OCA/rma/issues/268)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT39089