### PR TITLE
[14.0][FIX] rma (Singleton Error on Confirm)

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -635,7 +635,7 @@ class Rma(models.Model):
             if self.picking_id:
                 reception_move = self._create_receptions_from_picking()
             else:
-                reception_move = self._create_receptions_from_product()
+                reception_move = self._create_receptions_from_product()[0]
             self.write({"reception_move_id": reception_move.id, "state": "confirmed"})
             self._add_message_subscribe_partner()
             self._send_confirmation_email()


### PR DESCRIPTION
This is a fix for when a kit product is added to the RMA, a singleton error would show during confirm.

Create an RMA and add a kit product to the product field, click confirm and the following error will show:
  File "/odoo/addons/rma/models/rma.py", line 639, in action_confirm
    self.write({"reception_move_id": reception_move.id, "state": "confirmed"})
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 3818, in __get__
    raise ValueError("Expected singleton: %s" % record)