### PR TITLE
[13.0][FIX] rma_sale_mrp /rma : RMA reopening cases

### DIFF
--- a/rma/models/stock_move.py
+++ b/rma/models/stock_move.py
@@ -28,7 +28,9 @@ class StockMove(models.Model):
         rma_receiver = self.sudo().mapped("rma_receiver_ids")
         rma = self.sudo().mapped("rma_id")
         res = super().unlink()
-        rma_receiver.write({"state": "draft"})
+        rma_receiver.filtered(lambda x: x.state != "cancelled").write(
+            {"state": "draft"}
+        )
         rma.update_received_state()
         rma.update_replaced_state()
         return res

--- a/rma_sale_mrp/models/rma.py
+++ b/rma_sale_mrp/models/rma.py
@@ -62,3 +62,13 @@ class Rma(models.Model):
                     "state": "refunded",
                 }
             )
+
+    def action_draft(self):
+        if self.filtered(lambda r: r.state == "cancelled" and r.phantom_bom_product):
+            raise UserError(
+                _(
+                    "To avoid kit quantities inconsistencies it is not possible to convert "
+                    "to draft a cancelled RMA. You should do a new one from the sales order."
+                )
+            )
+        return super().action_draft()


### PR DESCRIPTION
**[FIX] rma_sale_mrp: avoid reopening of kit RMAs** 

- As we rely on the kit_qty field have the kit/component relation an that's computed when the RMA is created, we want to avoid reopening the RMA to avoid inconsitencies. The user should create a new RMA.

**[FIX] rma: avoid reopening a cancelled RMA when the reception is deleted** 

- When we delete the reception for an RMA, we're setting it to draft automatically so we can confirm it again and create a new reception. This is unconvenient when the RMA is cancelled, as we don't wan't to reopen it automatically.

cc @Tecnativa TT41943

please review @pedrobaeza @ernestotejeda 