### PR TITLE
[14.0][FIX] rma_sale_mrp: _check_rma_invoice_lines_qty 

### DIFF
--- a/rma_sale_mrp/models/account_move.py
+++ b/rma_sale_mrp/models/account_move.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Tecnativa - David Vidal
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
 from odoo.tools import float_compare
@@ -16,7 +17,8 @@ class AccountMove(models.Model):
         if lines:
             return lines.sudo().filtered(
                 lambda r: (
-                    r.rma_id.phantom_bom_product
+                    not r.rma_id.phantom_bom_product
+                    or r.rma_id.phantom_bom_product
                     and float_compare(r.quantity, r.rma_id.kit_qty, precision) < 0
                 )
             )

--- a/rma_sale_mrp/readme/CONTRIBUTORS.rst
+++ b/rma_sale_mrp/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * `Tecnativa <https://www.tecnativa.com>`__:
 
   * David Vidal
+* Michael Tietz (MT Software) <mtietz@mt-software.de>


### PR DESCRIPTION
checks now only lines with a phantom_bom_product set

If we are trying to post a refund for rma without kit and a lower qty than defined in the rma. 
There will no error thrown, as designed here https://github.com/OCA/rma/blob/50d86aedd57f8fcd6605768f2c9e59c76c58dd9b/rma/models/account_move.py#L30