### PR TITLE
[15.0][IMP] rma_sale: Link refund line with origin sale line

### DIFF
--- a/rma_sale/__manifest__.py
+++ b/rma_sale/__manifest__.py
@@ -13,6 +13,7 @@
     "depends": ["rma", "sale_stock"],
     "data": [
         "security/ir.model.access.csv",
+        "views/account_move_views.xml",
         "views/report_rma.xml",
         "views/rma_views.xml",
         "views/sale_views.xml",

--- a/rma_sale/models/__init__.py
+++ b/rma_sale/models/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import account_move
 from . import res_company
 from . import res_config_settings
 from . import rma

--- a/rma_sale/models/account_move.py
+++ b/rma_sale/models/account_move.py
@@ -22,3 +22,9 @@ class AccountMove(models.Model):
             if rma.sale_line_id:
                 rma._link_refund_with_reception_move()
         return super().button_draft()
+
+    def unlink(self):
+        """If the invoice is removed, rollback the quantities correction"""
+        for rma in self.invoice_line_ids.rma_id.filtered("sale_line_id"):
+            rma._unlink_refund_with_reception_move()
+        return super().unlink()

--- a/rma_sale/models/account_move.py
+++ b/rma_sale/models/account_move.py
@@ -1,0 +1,24 @@
+# Copyright 2023 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def button_cancel(self):
+        """If this a refund linked to an RMA, undo the linking of the reception move for
+        having proper quantities and status.
+        """
+        for rma in self.env["rma"].search([("refund_id", "in", self.ids)]):
+            if rma.sale_line_id:
+                rma._unlink_refund_with_reception_move()
+        return super().button_cancel()
+
+    def button_draft(self):
+        """Relink the reception move when passing the refund again to draft."""
+        for rma in self.env["rma"].search([("refund_id", "in", self.ids)]):
+            if rma.sale_line_id:
+                rma._link_refund_with_reception_move()
+        return super().button_draft()

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -96,16 +96,28 @@ class TestRmaSale(TestRmaSaleBase):
             rma.reception_move_id.picking_id + self.order_out_picking,
             order.picking_ids,
         )
-        # Refund the RMA
         user = self.env["res.users"].create(
             {"login": "test_refund_with_so", "name": "Test"}
         )
         order.user_id = user.id
+        # Receive the RMA
         rma.action_confirm()
         rma.reception_move_id.quantity_done = rma.product_uom_qty
         rma.reception_move_id.picking_id._action_done()
+        # Refund the RMA
         rma.action_refund()
+        self.assertEqual(self.order_line.qty_delivered, 0)
+        self.assertEqual(self.order_line.qty_invoiced, -5)
         self.assertEqual(rma.refund_id.user_id, user)
+        self.assertEqual(rma.refund_id.invoice_line_ids.sale_line_ids, self.order_line)
+        # Cancel the refund
+        rma.refund_id.button_cancel()
+        self.assertEqual(self.order_line.qty_delivered, 5)
+        self.assertEqual(self.order_line.qty_invoiced, 0)
+        # And put it to draft again
+        rma.refund_id.button_draft()
+        self.assertEqual(self.order_line.qty_delivered, 0)
+        self.assertEqual(self.order_line.qty_invoiced, -5)
 
     @users("partner@rma")
     def test_create_rma_from_so_portal_user(self):

--- a/rma_sale/views/account_move_views.xml
+++ b/rma_sale/views/account_move_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.form - Add helper sale_line_ids</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_line_ids']/tree" position="inside">
+                <field name="sale_line_ids" readonly="0" invisible="1" />
+            </xpath>
+            <xpath expr="//field[@name='line_ids']/tree" position="inside">
+                <field name="sale_line_ids" readonly="0" invisible="1" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
FW of #338 

@pedrobaeza :

Steps to reproduce:

- Create a sales order with an storable product with invoicing policy on delivered quantities.
- Confirm it and deliver the product.
- Invoice the order.
- Do an RMA, return it, and refund it.
- Result: the delivered quantity is 1 instead of 0.

This is because the refund generated from the RMA is not linked to sales order line, nor the RMA reception move. This is done because other operations are performed:

- Be replaced.
- Be changed by other product.

And we don't also want that meanwhile the RMA is being performed, the sales order is pending to invoice.

But when the refund has been done, we have it clear, so let's link both and have the sales statistics correct.

@chienandalu :

I've found that splitting the RMA leads to inconsistencies in delivered and invoiced quantities.

For example, if we receive an RMA for 5 units and return 2 to the customer and refund the remaining 3, we'll have a count of 0 delivered and 2 invoiced.

This is because once the reception is linked to the sale line we can't split those outcomes.

Given this issue, I think this should go at least behind a company setting as we discussed earlier.

@Tecnativa TT41645