### PR TITLE
[FIX] rma: Validation failed on products receiving while quantity is not an integer value

### DIFF
--- a/rma/models/stock_move.py
+++ b/rma/models/stock_move.py
@@ -59,7 +59,7 @@ class StockMove(models.Model):
         """
         for move in self.filtered(lambda r: r.state not in ("done", "cancel")):
             rma_receiver = move.sudo().rma_receiver_ids
-            if rma_receiver and move.quantity_done != rma_receiver.product_uom_qty:
+            if rma_receiver and float_compare(move.quantity_done, rma_receiver.product_uom_qty, 2)!=0:
                 raise ValidationError(
                     _(
                         "The quantity done for the product '%(id)s' must "


### PR DESCRIPTION
Fix float value comparison with "float_compare" instead of "=".