### PR TITLE
[15.0][FIX] rma_sale_mrp: sale wizard line edition

### DIFF
--- a/rma_sale_mrp/wizard/sale_order_rma_wizard_views.xml
+++ b/rma_sale_mrp/wizard/sale_order_rma_wizard_views.xml
@@ -11,8 +11,9 @@
             <xpath expr="//tree/field[@name='picking_id']" position="attributes">
                 <attribute
                     name="attrs"
-                >{'readonly': [('phantom_kit_line', '=', True)]}</attribute>
+                >{'readonly': [('phantom_kit_line', '=', True)], 'required': [('phantom_kit_line', '=', False)]}</attribute>
                 <attribute name="force_save">1</attribute>
+                <attribute name="required" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Whenever we tried to edit a line belonging to a kit we couldn't finsish the RMA. The wizard view was unwittingly requiring this field which for the kit line shouldn't be required.

cc @Tecnativa TT45051

please review @victoralmau @pedrobaeza 