### PR TITLE
[16.0][FIX] rma: `image_128` -> `avatar_128` (forward port)

### DIFF
--- a/rma/views/rma_team_views.xml
+++ b/rma/views/rma_team_views.xml
@@ -59,7 +59,7 @@
                                             >
                                                 <div class="o_kanban_record_top">
                                                     <img
-                                                        t-att-src="kanban_image('res.users', 'image_small', record.id.raw_value)"
+                                                        t-att-src="kanban_image('res.users', 'avatar_128', record.id.raw_value)"
                                                         height="40"
                                                         width="40"
                                                         class="oe_avatar oe_kanban_avatar_smallbox mb0"


### PR DESCRIPTION
Forward port of https://github.com/OCA/rma/pull/371.