### PR TITLE
[14.0][FIX] rma: fix error in refund button

### DIFF
--- a/rma/README.rst
+++ b/rma/README.rst
@@ -164,6 +164,9 @@ Contributors
 
 * Chafique Delli <chafique.delli@akretion.com>
 * Giovanni Serra - Ooops <giovanni@ooops404.com>
+* `Nuobit <https://www.nuobit.com>`_:
+
+  * Frank Cespedes <fcespedes@nuobit.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -1029,6 +1029,7 @@ class Rma(models.Model):
         """
         self.ensure_one()
         invoice_form.partner_id = self.partner_invoice_id
+        invoice_form.invoice_date = fields.Date.context_today(self)
         # Avoid set partner default value
         invoice_form.invoice_payment_term_id = self.env["account.payment.term"]
 

--- a/rma/readme/CONTRIBUTORS.rst
+++ b/rma/readme/CONTRIBUTORS.rst
@@ -6,3 +6,6 @@
 
 * Chafique Delli <chafique.delli@akretion.com>
 * Giovanni Serra - Ooops <giovanni@ooops404.com>
+* `Nuobit <https://www.nuobit.com>`_:
+
+  * Frank Cespedes <fcespedes@nuobit.com>

--- a/rma/static/description/index.html
+++ b/rma/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -518,6 +517,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li>Chafique Delli &lt;<a class="reference external" href="mailto:chafique.delli&#64;akretion.com">chafique.delli&#64;akretion.com</a>&gt;</li>
 <li>Giovanni Serra - Ooops &lt;<a class="reference external" href="mailto:giovanni&#64;ooops404.com">giovanni&#64;ooops404.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.nuobit.com">Nuobit</a>:<ul>
+<li>Frank Cespedes &lt;<a class="reference external" href="mailto:fcespedes&#64;nuobit.com">fcespedes&#64;nuobit.com</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
When you have generated an RMA and want to issue a refund, simply pressing the button results in:
![screenshot](https://github.com/OCA/rma/assets/121382390/d0bb6664-a93e-4f5a-bf62-67898d1c466f)

The error is:
```python
AssertionError: date is a required field ({'readonly': ['|', ('move_type', 'in', ['out_invoice', 'out_refund', 'out_receipt']), ('state', '!=', 'draft')], 'required': True})
```
The error occurs because the 'account.move' is created from the action_refund() with a Form(), and the date field is required, readonly, and not provided. Therefore, the invoice_date must be provided for it to execute:
```python
    @api.onchange('invoice_date', 'highest_name', 'company_id')
    def _onchange_invoice_date(self):
        if self.invoice_date:
            if not self.invoice_payment_term_id and (not self.invoice_date_due or self.invoice_date_due < self.invoice_date):
                self.invoice_date_due = self.invoice_date

            has_tax = bool(self.line_ids.tax_ids or self.line_ids.tax_tag_ids)
            accounting_date = self._get_accounting_date(self.invoice_date, has_tax)
            if accounting_date != self.date:
                self.date = accounting_date
                self._onchange_currency()
            else:
                self._onchange_recompute_dynamic_lines()
```