### PR TITLE
[17.0] [FIX] uom_id in rma report

### DIFF
--- a/rma/views/report_rma.xml
+++ b/rma/views/report_rma.xml
@@ -110,9 +110,9 @@
                     </div>
                     <div t-if="doc.product_id" class="col-auto mw-100 mb-2">
                         <strong>Quantity:</strong>
-                        <p class="m-0" t-field="doc.product_uom_qty">
+                        <p class="m-0">
                             <span t-field="doc.product_uom_qty" />
-                            <span t-field="doc.uom_id" groups="uom.group_uom" />
+                            <span t-field="doc.product_uom" groups="uom.group_uom" />
                         </p>
                     </div>
                     <div t-if="doc.delivered_qty" class="col-auto mw-100 mb-2">


### PR DESCRIPTION
Field name is wrong in report. uom_id doesn't exist in model rma.

Same as in PR https://github.com/OCA/rma/pull/387, just without the changes in rma_sale_mrp because this module wasn't migrated yet