### PR TITLE
[16.0][OU-FIX] rma: Improve migration script to create picking types (only if not set)

### DIFF
--- a/rma/migrations/16.0.1.4.0/post-migration.py
+++ b/rma/migrations/16.0.1.4.0/post-migration.py
@@ -10,5 +10,8 @@ def migrate(env, version):
     warehouses = env["stock.warehouse"].search([])
     warehouses = warehouses.with_context(rma_post_init_hook=True)
     for wh in warehouses:
+        if not wh.rma_in_type_id or not wh.rma_out_type_id:
+            data = wh._create_or_update_sequences_and_picking_types()
+            wh.write(data)
         route_vals = wh._create_or_update_route()
         wh.write(route_vals)

--- a/rma/models/stock_warehouse.py
+++ b/rma/models/stock_warehouse.py
@@ -123,12 +123,13 @@ class StockWarehouse(models.Model):
 
     def _get_picking_type_update_values(self):
         data = super()._get_picking_type_update_values()
-        data.update(
-            {
-                "rma_in_type_id": {"default_location_dest_id": self.rma_loc_id.id},
-                "rma_out_type_id": {"default_location_src_id": self.rma_loc_id.id},
-            }
-        )
+        picking_types = {
+            "rma_in_type_id": {"default_location_dest_id": self.rma_loc_id.id},
+            "rma_out_type_id": {"default_location_src_id": self.rma_loc_id.id},
+        }
+        if self.env.context.get("rma_post_init_hook"):
+            return picking_types
+        data.update(picking_types)
         return data
 
     def _create_or_update_sequences_and_picking_types(self):

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -4,6 +4,7 @@
 
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import Form, TransactionCase, new_test_user, users
+from odoo.tools import mute_logger
 
 from .. import hooks
 
@@ -761,6 +762,7 @@ class TestRmaCase(TestRma):
         self.assertEqual(new_rma.move_id.quantity_done, 10)
         self.assertEqual(new_rma.reception_move_id.quantity_done, 10)
 
+    @mute_logger("odoo.models.unlink")
     def test_rma_to_receive_on_delete_invoice(self):
         rma = self._create_confirm_receive(self.partner, self.product, 10, self.rma_loc)
         rma.action_refund()


### PR DESCRIPTION
Improve migration script to create picking types (only if not set)

Fixes https://github.com/OCA/rma/issues/395

@Tecnativa