### PR TITLE
[16.0][FIX] rma: Add location_id field for the expected behavior

### DIFF
--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -76,7 +76,6 @@ class TestRma(TransactionCase):
             {"name": "[Test] It's out of warranty. To be scrapped"}
         )
         cls.env.ref("rma.group_rma_manual_finalization").users |= cls.env.user
-        cls.env.ref("stock.group_stock_multi_locations").users |= cls.env.user
         cls.warehouse = cls.env.ref("stock.warehouse0")
         # Ensure grouping
         cls.env.company.rma_return_grouping = True

--- a/rma/wizard/stock_picking_return_views.xml
+++ b/rma/wizard/stock_picking_return_views.xml
@@ -17,6 +17,7 @@
                     <field name="rma_location_ids" invisible="1" />
                     <field name="picking_id" invisible="1" />
                     <field name="picking_type_code" invisible="1" />
+                    <field name="location_id" invisible="1" />
                 </group>
             </field>
         </field>


### PR DESCRIPTION
The `location_id` field is important and its value is required, we need to add it to the wizard (even if it is hidden) so that it is saved and the picking is created correctly.

Before, the `location_id` value was only saved (although the field was not in the wizard) if the user had the "_Technical / Manage Multiple Stock Locations_" permission.

@Tecnativa