### PR TITLE
[16.0][IMP] rma_sale: Display the allowed quantity to return in the RMA wizard

### DIFF
--- a/rma_sale/README.rst
+++ b/rma_sale/README.rst
@@ -106,6 +106,8 @@ Contributors
 
 * Chafique Delli <chafique.delli@akretion.com>
 * Giovanni Serra - Ooops <giovanni@ooops404.com>
+* Souheil Bejaoui - ACSONE SA/NV <souheil.bejaoui@acsone.eu>
+* Jacques-Etienne Baudoux - BCIM <je@bcim.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/rma_sale/controllers/sale_portal.py
+++ b/rma_sale/controllers/sale_portal.py
@@ -25,6 +25,7 @@ class CustomerPortal(CustomerPortal):
         except (AccessError, MissingError):
             return request.redirect("/my")
         order_obj = request.env["sale.order"]
+        order_line_obj = request.env["sale.order.line"]
         wizard_obj = request.env["sale.order.rma.wizard"].sudo()
         wizard_line_field_types = {
             f: d["type"] for f, d in wizard_obj.line_ids.fields_get().items()
@@ -48,6 +49,9 @@ class CustomerPortal(CustomerPortal):
             # description values
             except ValueError:
                 custom_vals.update({name: value})
+        for vals in mapped_vals.values():
+            sale_line = order_line_obj.browse(vals.get("sale_line_id")).sudo()
+            vals["allowed_quantity"] = sale_line.qty_delivered
         # If no operation is filled, no RMA will be created
         line_vals = [
             (0, 0, vals) for vals in mapped_vals.values() if vals.get("operation_id")

--- a/rma_sale/models/sale.py
+++ b/rma_sale/models/sale.py
@@ -31,6 +31,7 @@ class SaleOrder(models.Model):
         return {
             "product_id": data["product"].id,
             "quantity": data["quantity"],
+            "allowed_quantity": data["quantity"],
             "sale_line_id": data["sale_line_id"].id,
             "uom_id": data["uom"].id,
             "picking_id": data["picking"] and data["picking"].id,

--- a/rma_sale/readme/CONTRIBUTORS.rst
+++ b/rma_sale/readme/CONTRIBUTORS.rst
@@ -7,3 +7,5 @@
 
 * Chafique Delli <chafique.delli@akretion.com>
 * Giovanni Serra - Ooops <giovanni@ooops404.com>
+* Souheil Bejaoui - ACSONE SA/NV <souheil.bejaoui@acsone.eu>
+* Jacques-Etienne Baudoux - BCIM <je@bcim.be>

--- a/rma_sale/static/description/index.html
+++ b/rma_sale/static/description/index.html
@@ -455,6 +455,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li>Chafique Delli &lt;<a class="reference external" href="mailto:chafique.delli&#64;akretion.com">chafique.delli&#64;akretion.com</a>&gt;</li>
 <li>Giovanni Serra - Ooops &lt;<a class="reference external" href="mailto:giovanni&#64;ooops404.com">giovanni&#64;ooops404.com</a>&gt;</li>
+<li>Souheil Bejaoui - ACSONE SA/NV &lt;<a class="reference external" href="mailto:souheil.bejaoui&#64;acsone.eu">souheil.bejaoui&#64;acsone.eu</a>&gt;</li>
+<li>Jacques-Etienne Baudoux - BCIM &lt;<a class="reference external" href="mailto:je&#64;bcim.be">je&#64;bcim.be</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/rma_sale/tests/__init__.py
+++ b/rma_sale/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_rma_sale
 from . import test_rma_sale_portal
+from . import test_rma_sale_allowed_qty

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -191,6 +191,7 @@ class TestRmaSale(TestRmaSaleBase):
                     "product_id": order.order_line.product_id.id,
                     "sale_line_id": order.order_line.id,
                     "quantity": order.order_line.product_uom_qty,
+                    "allowed_quantity": order.order_line.qty_delivered,
                     "uom_id": order.order_line.product_uom.id,
                     "picking_id": order.picking_ids[0].id,
                     "operation_id": operation.id,

--- a/rma_sale/tests/test_rma_sale_allowed_qty.py
+++ b/rma_sale/tests/test_rma_sale_allowed_qty.py
@@ -1,0 +1,110 @@
+# Copyright 2024 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import Command
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class TestRmaSaleQuantityAllowed(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.loc_stock = cls.warehouse.lot_stock_id
+        cls.partner1 = cls.env["res.partner"].create({"name": "Partner"})
+        cls.p1 = cls.env["product.product"].create(
+            {"name": "Unittest P1", "type": "product"}
+        )
+        cls.so = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner1.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "name": cls.p1.name,
+                            "product_id": cls.p1.id,
+                            "product_uom_qty": 5,
+                            "price_unit": 50,
+                        },
+                    )
+                ],
+            }
+        )
+        cls.env["stock.quant"].with_context(inventory_mode=True).create(
+            {
+                "product_id": cls.p1.id,
+                "inventory_quantity": 10,
+                "location_id": cls.loc_stock.id,
+            }
+        )._apply_inventory()
+        cls.so.action_confirm()
+        cls.picking = cls.so.picking_ids[0]
+
+    def _get_rma_wizard(self):
+        action = self.so.action_create_rma()
+        return self.env[action.get("res_model")].browse(action.get("res_id"))
+
+    def _deliver(self, qty):
+        self.picking.move_line_ids.qty_done = qty
+        self.picking._action_done()
+        self.assertEqual(self.picking.state, "done")
+        self.assertEqual(self.so.order_line.qty_delivered, qty)
+
+    def test_1(self):
+        """
+        Test rma wizard:
+
+            - fully deliver the so
+            - open rma wizard
+        expected:
+            - qty proposed: 5
+            - allowed qty 5
+            - qty 0 if is_return_all = False
+        """
+        self._deliver(5)
+        wizard = self._get_rma_wizard()
+        self.assertEqual(len(wizard.line_ids), 1)
+        self.assertEqual(wizard.line_ids.quantity, 5)
+        self.assertEqual(wizard.line_ids.allowed_quantity, 5)
+        wizard.is_return_all = False
+        self.assertEqual(wizard.line_ids.quantity, 0)
+        wizard.is_return_all = True
+        self.assertEqual(wizard.line_ids.quantity, 5)
+
+    def test_2(self):
+        """
+        Test rma wizard:
+
+            - partially deliver the so
+            - open rma wizard
+        expected:
+            - qty proposed: 3
+            - allowed qty 3
+            - qty 0 if is_return_all = False
+        """
+        self._deliver(3)
+        wizard = self._get_rma_wizard()
+        self.assertEqual(len(wizard.line_ids), 1)
+        self.assertEqual(wizard.line_ids.quantity, 3)
+        self.assertEqual(wizard.line_ids.allowed_quantity, 3)
+        wizard.is_return_all = False
+        self.assertEqual(wizard.line_ids.quantity, 0)
+        wizard.is_return_all = True
+        self.assertEqual(wizard.line_ids.quantity, 3)
+
+    def test_3(self):
+        """
+        Test rma wizard:
+            Try to return more than the allowed qty
+        """
+        self._deliver(3)
+        wizard = self._get_rma_wizard()
+        self.assertEqual(len(wizard.line_ids), 1)
+        self.assertEqual(wizard.line_ids.quantity, 3)
+        self.assertEqual(wizard.line_ids.allowed_quantity, 3)
+        with self.assertRaises(
+            ValidationError, msg="You can't exceed the allowed quantity"
+        ):
+            wizard.line_ids.quantity = 5
+        wizard.line_ids.quantity = 1

--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -1,8 +1,11 @@
 # Copyright 2020 Tecnativa - Ernesto Tejeda
 # Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2024 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import SUPERUSER_ID, _, api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools.float_utils import float_compare
 
 
 class SaleOrderRmaWizard(models.TransientModel):
@@ -50,6 +53,7 @@ class SaleOrderRmaWizard(models.TransientModel):
     custom_description = fields.Text(
         help="Values coming from portal RMA request form custom fields",
     )
+    is_return_all = fields.Boolean(string="Return All?", default=True)
 
     def create_rma(self, from_portal=False):
         self.ensure_one()
@@ -130,7 +134,11 @@ class SaleOrderLineRmaWizard(models.TransientModel):
     quantity = fields.Float(
         digits="Product Unit of Measure",
         required=True,
+        compute="_compute_quantity",
+        store=True,
+        readonly=False,
     )
+    allowed_quantity = fields.Float(digits="Product Unit of Measure", readonly=True)
     uom_id = fields.Many2one(
         comodel_name="uom.uom",
         string="Unit of Measure",
@@ -157,6 +165,14 @@ class SaleOrderLineRmaWizard(models.TransientModel):
         comodel_name="sale.order.line",
     )
     description = fields.Text()
+
+    @api.depends("wizard_id.is_return_all", "allowed_quantity")
+    def _compute_quantity(self):
+        for rec in self:
+            if not rec.wizard_id.is_return_all:
+                rec.quantity = 0
+            else:
+                rec.quantity = rec.allowed_quantity
 
     @api.depends("wizard_id.operation_id")
     def _compute_operation_id(self):
@@ -199,6 +215,26 @@ class SaleOrderLineRmaWizard(models.TransientModel):
             record.allowed_picking_ids = line.mapped("move_ids.picking_id").filtered(
                 lambda x: x.state == "done"
             )
+
+    @api.constrains("quantity", "allowed_quantity")
+    def _check_quantity(self):
+        precision = self.env["decimal.precision"].precision_get(
+            "Product Unit of Measure"
+        )
+        for rec in self:
+            if (
+                float_compare(
+                    rec.quantity, rec.allowed_quantity, precision_digits=precision
+                )
+                == 1
+            ):
+                raise ValidationError(
+                    _(
+                        "You can't exceed the allowed quantity for returning product "
+                        "%(product)s.",
+                        product=rec.product_id.display_name,
+                    )
+                )
 
     def _prepare_rma_values(self):
         self.ensure_one()

--- a/rma_sale/wizard/sale_order_rma_wizard_views.xml
+++ b/rma_sale/wizard/sale_order_rma_wizard_views.xml
@@ -12,6 +12,7 @@
         <field name="arch" type="xml">
             <form>
                 <group>
+                    <field name="is_return_all" widget="boolean_toggle" />
                     <field name="operation_id" />
                     <field name="line_ids" nolabel="1" colspan="2">
                         <tree editable="bottom">
@@ -19,6 +20,7 @@
                             <field name="allowed_product_ids" invisible="1" />
                             <field name="product_id" options="{'no_create': True}" />
                             <field name="quantity" />
+                            <field name="allowed_quantity" />
                             <field name="uom_category_id" invisible="1" />
                             <field
                                 name="uom_id"

--- a/rma_sale_mrp/tests/test_rma_sale_mrp.py
+++ b/rma_sale_mrp/tests/test_rma_sale_mrp.py
@@ -135,9 +135,8 @@ class TestRmaSaleMrp(TestRmaSaleBase):
         # be 0 at this time
         wizard = self._rma_sale_wizard(order)
         self.assertEqual(wizard.line_ids.quantity, 0)
-        wizard.line_ids.quantity = 1
         with self.assertRaises(ValidationError):
-            wizard.create_and_open_rma()
+            wizard.line_ids.quantity = 1
 
     def test_report_rma(self):
         wizard = self._rma_sale_wizard(self.sale_order)

--- a/rma_sale_reason/tests/test_rma_sale_reason.py
+++ b/rma_sale_reason/tests/test_rma_sale_reason.py
@@ -4,7 +4,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 
-from odoo import Command
 from odoo.tests.common import users
 
 from odoo.addons.rma_sale.tests.test_rma_sale import TestRmaSaleBase
@@ -26,29 +25,11 @@ class TestRmaSaleReason(TestRmaSaleBase):
         cls.order_out_picking.button_validate()
 
     def _create_wizard(self):
-        order = self.sale_order
-        wizard_obj = (
-            self.env["sale.order.rma.wizard"].sudo().with_context(active_id=order.id)
-        )
-
-        line_vals = [
-            Command.create(
-                {
-                    "product_id": order.order_line.product_id.id,
-                    "sale_line_id": order.order_line.id,
-                    "quantity": order.order_line.product_uom_qty,
-                    "uom_id": order.order_line.product_uom.id,
-                    "picking_id": order.picking_ids[0].id,
-                    "operation_id": self.operation.id,
-                },
-            )
-        ]
-        return wizard_obj.create(
-            {
-                "line_ids": line_vals,
-                "location_id": order.warehouse_id.rma_loc_id.id,
-            }
-        )
+        order = self.sale_order.sudo()
+        wizard_id = order.action_create_rma()["res_id"]
+        wizard = self.env["sale.order.rma.wizard"].sudo().browse(wizard_id)
+        wizard.operation_id = self.operation
+        return wizard
 
     @users("partner@rma")
     def test_create_rma_from_wizard(self):


### PR DESCRIPTION
fixes: #406 

- Display the allowed quantity to return
- Simplify data encoding by adding a button to select/deselect all lines
- Ensure that the quantity to return is always less than or equal to the allowed quantity

![image](https://github.com/user-attachments/assets/dd38d254-9eab-4fb7-a844-6265702fdd5e)
