### PR TITLE
[16.0][IMP] create a replacement order upon confirmation

### DIFF
--- a/rma/__manifest__.py
+++ b/rma/__manifest__.py
@@ -35,6 +35,7 @@
         "views/stock_picking_views.xml",
         "views/stock_warehouse_views.xml",
         "views/res_config_settings_views.xml",
+        "views/rma_operation.xml",
     ],
     "post_init_hook": "post_init_hook",
     "application": True,

--- a/rma/models/rma_operation.py
+++ b/rma/models/rma_operation.py
@@ -9,6 +9,9 @@ class RmaOperation(models.Model):
     _description = "RMA requested operation"
 
     active = fields.Boolean(default=True)
+    create_replacement_at_confirmation = fields.Boolean(
+        help="Create the replacement picking upon confirmation."
+    )
     name = fields.Char(required=True, translate=True)
 
     _sql_constraints = [

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -832,3 +832,20 @@ class TestRmaCase(TestRma):
         )
         self.assertTrue(rma.name in mail_receipt.subject)
         self.assertTrue("products received" in mail_receipt.subject)
+
+    def test_confirm_and_replace(self):
+        operation = self.env.ref("rma.rma_operation_replace")
+        operation.create_replacement_at_confirmation = True
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        rma.operation_id = operation
+        rma.action_confirm()
+        self.assertEqual(rma.reception_move_id.picking_id.state, "assigned")
+        self.assertEqual(rma.reception_move_id.product_id, rma.product_id)
+        self.assertEqual(rma.reception_move_id.product_uom_qty, 10)
+        self.assertEqual(rma.reception_move_id.product_uom, rma.product_uom)
+        self.assertEqual(rma.state, "waiting_replacement")
+        self.assertEqual(rma.delivery_picking_count, 1)
+        delivery_move = rma.delivery_move_ids
+        self.assertEqual(delivery_move.product_id, rma.product_id)
+        self.assertEqual(delivery_move.product_uom_qty, 10)
+        self.assertEqual(rma.reception_move_id.product_uom, rma.product_uom)

--- a/rma/views/rma_operation.xml
+++ b/rma/views/rma_operation.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 ACSONE SA/NV
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="rma_operation_form_view">
+        <field name="model">rma.operation</field>
+        <field name="arch" type="xml">
+            <form>
+
+                <sheet>
+                    <group>
+                        <field name="name" />
+                        <field
+                            name="create_replacement_at_confirmation"
+                            widget="boolean_toggle"
+                        />
+                        <field name="active" widget="boolean_toggle" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="rma_operation_search_view">
+        <field name="model">rma.operation</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" />
+            </search>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="rma_operation_tree_view">
+        <field name="model">rma.operation</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="active" widget="boolean_toggle" />
+            </tree>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="rma_operation_act_window">
+        <field name="name">Operations</field>
+        <field name="res_model">rma.operation</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[]</field>
+        <field name="context">{}</field>
+    </record>
+
+    <record model="ir.ui.menu" id="rma_operation_menu">
+        <field name="name">Operations</field>
+        <field name="parent_id" ref="rma_configuration_menu" />
+        <field name="action" ref="rma_operation_act_window" />
+        <field name="sequence" eval="16" />
+    </record>
+
+</odoo>


### PR DESCRIPTION
In some use cases, a product replacement happens as an exchange when the business manages its own transport. This PR allows configuring the operation in a way that generates the replacement delivery upon rma confirmation

@jbaudoux 

fixes first point of #408 
