### PR TITLE
[16.0][FIX] rma_sale: Fix problems with link between RMA-sale.order and procurement.group-sale.order when creating from stock.picking.return wizard

### DIFF
--- a/rma_sale/wizard/stock_picking_return.py
+++ b/rma_sale/wizard/stock_picking_return.py
@@ -17,8 +17,8 @@ class ReturnPicking(models.TransientModel):
             sale_order.partner_shipping_id,
         )
 
-    def _prepare_rma_values(self):
-        vals = super()._prepare_rma_values()
+    def _prepare_rma_vals(self):
+        vals = super()._prepare_rma_vals()
         sale_order = self.picking_id.sale_id
         if sale_order:
             vals.update(


### PR DESCRIPTION
## Module
rma_sale

## Describe the bug
There's some bugs in the rma_sale module when creating a return from the stock.picking.return wizard with the create_rma flag set.

## To Reproduce
**Affected versions:**

Steps to reproduce the behavior:

1. Create a sale.order with a picking
2. Validate the picking
3. Create a return with the create_rma flag set.

**Expected behavior**
The order_id on the RMA and sale_id on the new procurement.group are set
