### PR TITLE
[IMP] rma: configurable workflow

### DIFF
--- a/rma/__manifest__.py
+++ b/rma/__manifest__.py
@@ -36,6 +36,7 @@
         "views/stock_warehouse_views.xml",
         "views/dashboard.xml",
         "views/res_config_settings_views.xml",
+        "views/rma_operation.xml",
     ],
     "post_init_hook": "post_init_hook",
     "application": True,

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -774,6 +774,7 @@ class Rma(models.Model):
         vals = self._prepare_common_procurement_vals(group=group)
         vals["route_ids"] = self.warehouse_id.rma_in_route_id
         vals["rma_receiver_ids"] = [(6, 0, self.ids)]
+        vals["to_refund"] = self.operation_id.action_create_refund == "update_quantity"
         if self.move_id:
             vals["origin_returned_move_id"] = self.move_id.id
         return vals

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -785,6 +785,8 @@ class Rma(models.Model):
         vals["to_refund"] = self.operation_id.action_create_refund == "update_quantity"
         if self.move_id:
             vals["origin_returned_move_id"] = self.move_id.id
+            if not self.operation_id.different_return_product:
+                vals["move_orig_ids"] = [(6, 0, self.move_id.ids)]
         return vals
 
     def _prepare_reception_procurements(self):

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -861,8 +861,8 @@ class Rma(models.Model):
                     rma_return_grouping=rec.env.company.rma_return_grouping
                 ).create_replace(
                     fields.Datetime.now(),
-                    self.warehouse_id,
-                    self.product_id,
+                    rec.warehouse_id,
+                    rec.product_id,
                     rec.product_uom_qty,
                     rec.product_uom,
                 )
@@ -1511,8 +1511,8 @@ class Rma(models.Model):
                     rma_return_grouping=rec.env.company.rma_return_grouping
                 ).create_replace(
                     fields.Datetime.now(),
-                    self.warehouse_id,
-                    self.product_id,
+                    rec.warehouse_id,
+                    rec.product_id,
                     rec.product_uom_qty,
                     rec.product_uom,
                 )

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -317,6 +317,55 @@ class Rma(models.Model):
         copy=False,
     )
 
+    show_create_receipt = fields.Boolean(
+        string="Show Create Receipt Button", compute="_compute_show_create_receipt"
+    )
+    show_create_return = fields.Boolean(
+        string="Show Create Return Button", compute="_compute_show_create_return"
+    )
+    show_create_replace = fields.Boolean(
+        string="Show Create replace Button", compute="_compute_show_create_replace"
+    )
+    show_create_refund = fields.Boolean(
+        string="Show Create refund Button", compute="_compute_show_refund_replace"
+    )
+
+    @api.depends("operation_id.action_create_receipt", "state", "reception_move_id")
+    def _compute_show_create_receipt(self):
+        for rec in self:
+            rec.show_create_receipt = (
+                not rec.reception_move_id
+                and rec.operation_id.action_create_receipt == "manual_on_confirm"
+                and rec.state == "confirmed"
+            )
+
+    @api.depends("operation_id.action_create_delivery", "can_be_returned")
+    def _compute_show_create_return(self):
+        for rec in self:
+            rec.show_create_return = (
+                rec.operation_id.action_create_delivery
+                in ("manual_on_confirm", "manual_after_receipt")
+                and rec.can_be_returned
+            )
+
+    @api.depends("operation_id.action_create_delivery", "can_be_replaced")
+    def _compute_show_create_replace(self):
+        for rec in self:
+            rec.show_create_replace = (
+                rec.operation_id.action_create_delivery
+                in ("manual_on_confirm", "manual_after_receipt")
+                and rec.can_be_replaced
+            )
+
+    @api.depends("operation_id.action_create_refund", "can_be_refunded")
+    def _compute_show_refund_replace(self):
+        for rec in self:
+            rec.show_create_refund = (
+                rec.operation_id.action_create_refund
+                in ("manual_on_confirm", "manual_after_receipt")
+                and rec.can_be_refunded
+            )
+
     def _compute_delivery_picking_count(self):
         for rma in self:
             rma.delivery_picking_count = len(rma.delivery_move_ids.picking_id)
@@ -394,9 +443,17 @@ class Rma(models.Model):
         an rma can be refunded. It is used in rma.action_refund method.
         """
         for record in self:
-            record.can_be_refunded = record.state == "received"
+            record.can_be_refunded = (
+                record.operation_id.action_create_refund
+                in ("manual_after_receipt", "automatic_after_receipt")
+                and record.state == "received"
+            ) or (
+                record.operation_id.action_create_refund
+                in ("manual_on_confirm", "automatic_on_confirm")
+                and record.state == "confirmed"
+            )
 
-    @api.depends("remaining_qty", "state")
+    @api.depends("remaining_qty", "state", "operation_id.action_create_delivery")
     def _compute_can_be_returned(self):
         """Compute 'can_be_returned'. This field controls the visibility
         of the 'Return to customer' button in the rma form
@@ -406,8 +463,17 @@ class Rma(models.Model):
         rma._ensure_can_be_returned.
         """
         for r in self:
-            r.can_be_returned = (
-                r.state in ["received", "waiting_return"] and r.remaining_qty > 0
+            r.can_be_returned = r.remaining_qty > 0 and (
+                (
+                    r.operation_id.action_create_delivery
+                    in ("manual_after_receipt", "automatic_after_receipt")
+                    and r.state in ["received", "waiting_return"]
+                )
+                or (
+                    r.operation_id.action_create_delivery
+                    in ("manual_on_confirm", "automatic_on_confirm")
+                    and r.state == "confirmed"
+                )
             )
 
     @api.depends("state")
@@ -420,11 +486,20 @@ class Rma(models.Model):
         rma._ensure_can_be_replaced.
         """
         for r in self:
-            r.can_be_replaced = r.state in [
-                "received",
-                "waiting_replacement",
-                "replaced",
-            ]
+            r.can_be_replaced = (
+                r.operation_id.action_create_delivery
+                in ("manual_after_receipt", "automatic_after_receipt")
+                and r.state
+                in [
+                    "received",
+                    "waiting_replacement",
+                    "replaced",
+                ]
+            ) or (
+                r.operation_id.action_create_delivery
+                in ("manual_on_confirm", "automatic_on_confirm")
+                and r.state == "confirmed"
+            )
 
     @api.depends("state", "remaining_qty")
     def _compute_can_be_finished(self):
@@ -726,20 +801,47 @@ class Rma(models.Model):
             )
         return procurements
 
+    def _create_receipt(self):
+        procurements = self._prepare_reception_procurements()
+        if procurements:
+            self.env["procurement.group"].run(procurements)
+        self.reception_move_id.picking_id.action_assign()
+
+    def action_create_receipt(self):
+        self.ensure_one()
+        self._create_receipt()
+        self.ensure_one()
+        return {
+            "name": _("Receipt"),
+            "type": "ir.actions.act_window",
+            "view_type": "form",
+            "view_mode": "form",
+            "res_model": "stock.picking",
+            "views": [[False, "form"]],
+            "res_id": self.reception_move_id.picking_id.id,
+        }
+
     def action_confirm(self):
         """Invoked when 'Confirm' button in rma form view is clicked."""
         self._ensure_required_fields()
         self = self.filtered(lambda rma: rma.state == "draft")
         if not self:
             return
-        procurements = self._prepare_reception_procurements()
-        if procurements:
-            self.env["procurement.group"].run(procurements)
-        self.reception_move_id.picking_id.action_assign()
         self.write({"state": "confirmed"})
         for rma in self:
             rma._add_message_subscribe_partner()
         self._send_confirmation_email()
+        for rec in self:
+            if rec.operation_id.action_create_receipt == "automatic_on_confirm":
+                rec._create_receipt()
+            if rec.operation_id.action_create_delivery == "automatic_on_confirm":
+                rec.with_context(
+                    rma_return_grouping=rec.env.company.rma_return_grouping
+                ).create_return(
+                    fields.Datetime.now(), rec.product_uom_qty, rec.product_uom
+                )
+            if rec.operation_id.action_create_refund == "automatic_on_confirm":
+                rec.action_refund()
 
     def action_refund(self):
         """Invoked when 'Refund' button in rma form view is clicked
@@ -1377,6 +1479,15 @@ class Rma(models.Model):
         """
         self.write({"state": "received"})
         self._send_receipt_confirmation_email()
+        for rec in self:
+            if rec.operation_id.action_create_delivery == "automatic_after_receipt":
+                rec.with_context(
+                    rma_return_grouping=rec.env.company.rma_return_grouping
+                ).create_return(
+                    fields.Datetime.now(), rec.product_uom_qty, rec.product_uom
+                )
+            if rec.operation_id.action_create_refund == "automatic_after_receipt":
+                rec.action_refund()
 
     def update_received_state(self):
         """Invoked by:

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -857,8 +857,12 @@ class Rma(models.Model):
             if rec.operation_id.action_create_delivery == "automatic_on_confirm":
                 rec.with_context(
                     rma_return_grouping=rec.env.company.rma_return_grouping
-                ).create_return(
-                    fields.Datetime.now(), rec.product_uom_qty, rec.product_uom
+                ).create_replace(
+                    fields.Datetime.now(),
+                    self.warehouse_id,
+                    self.product_id,
+                    rec.product_uom_qty,
+                    rec.product_uom,
                 )
             if rec.operation_id.action_create_refund == "automatic_on_confirm":
                 rec.action_refund()
@@ -1503,9 +1507,14 @@ class Rma(models.Model):
             if rec.operation_id.action_create_delivery == "automatic_after_receipt":
                 rec.with_context(
                     rma_return_grouping=rec.env.company.rma_return_grouping
-                ).create_return(
-                    fields.Datetime.now(), rec.product_uom_qty, rec.product_uom
+                ).create_replace(
+                    fields.Datetime.now(),
+                    self.warehouse_id,
+                    self.product_id,
+                    rec.product_uom_qty,
+                    rec.product_uom,
                 )
+
             if rec.operation_id.action_create_refund == "automatic_after_receipt":
                 rec.action_refund()
 

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -828,6 +828,9 @@ class Rma(models.Model):
         if procurements:
             self.env["procurement.group"].run(procurements)
         self.reception_move_id.picking_id.action_assign()
+        if self.operation_id.auto_confirm_reception:
+            self.reception_move_id._set_quantities_to_reservation()
+            self.reception_move_id._action_done()
 
     def action_create_receipt(self):
         self.ensure_one()

--- a/rma/models/rma_operation.py
+++ b/rma/models/rma_operation.py
@@ -34,6 +34,10 @@ class RmaOperation(models.Model):
         help="If checked, allows the return of a product different from the one "
         "originally ordered. Used if the delivery is created automatically",
     )
+    auto_confirm_reception = fields.Boolean(
+        help="Enable this option to automatically confirm the reception when the RMA is"
+        " confirmed."
+    )
     action_create_delivery = fields.Selection(
         [
             ("manual_on_confirm", "Manually on Confirm"),

--- a/rma/models/rma_operation.py
+++ b/rma/models/rma_operation.py
@@ -21,6 +21,37 @@ class RmaOperation(models.Model):
     count_rma_draft = fields.Integer(compute="_compute_count_rma")
     count_rma_awaiting_action = fields.Integer(compute="_compute_count_rma")
     count_rma_processed = fields.Integer(compute="_compute_count_rma")
+    action_create_receipt = fields.Selection(
+        [
+            ("manual_on_confirm", "Manually on Confirm"),
+            ("automatic_on_confirm", "Automatically on Confirm"),
+        ],
+        string="Create Receipt",
+        default="automatic_on_confirm",
+        help="Define how the receipt action should be handled.",
+    )
+    action_create_delivery = fields.Selection(
+        [
+            ("manual_on_confirm", "Manually on Confirm"),
+            ("automatic_on_confirm", "Automatically on Confirm"),
+            ("manual_after_receipt", "Manually After Receipt"),
+            ("automatic_after_receipt", "Automatically After Receipt"),
+        ],
+        string="Delivery Action",
+        help="Define how the delivery action should be handled.",
+        default="manual_after_receipt",
+    )
+    action_create_refund = fields.Selection(
+        [
+            ("manual_on_confirm", "Manually on Confirm"),
+            ("automatic_on_confirm", "Automatically on Confirm"),
+            ("manual_after_receipt", "Manually After Receipt"),
+            ("automatic_after_receipt", "Automatically After Receipt"),
+        ],
+        string="Refund Action",
+        default="manual_after_receipt",
+        help="Define how the refund action should be handled.",
+    )
 
     _sql_constraints = [
         ("name_uniq", "unique (name)", "That operation name already exists !"),

--- a/rma/models/rma_operation.py
+++ b/rma/models/rma_operation.py
@@ -30,6 +30,10 @@ class RmaOperation(models.Model):
         default="automatic_on_confirm",
         help="Define how the receipt action should be handled.",
     )
+    different_return_product = fields.Boolean(
+        help="If checked, allows the return of a product different from the one "
+        "originally ordered. Used if the delivery is created automatically",
+    )
     action_create_delivery = fields.Selection(
         [
             ("manual_on_confirm", "Manually on Confirm"),

--- a/rma/models/rma_operation.py
+++ b/rma/models/rma_operation.py
@@ -47,6 +47,7 @@ class RmaOperation(models.Model):
             ("automatic_on_confirm", "Automatically on Confirm"),
             ("manual_after_receipt", "Manually After Receipt"),
             ("automatic_after_receipt", "Automatically After Receipt"),
+            ("update_quantity", "Update Quantities"),
         ],
         string="Refund Action",
         default="manual_after_receipt",

--- a/rma/static/description/index.html
+++ b/rma/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -530,9 +529,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/rma/tests/__init__.py
+++ b/rma/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_rma
 from . import test_rma_dashboard
+from . import test_rma_operation

--- a/rma/tests/test_rma_operation.py
+++ b/rma/tests/test_rma_operation.py
@@ -1,0 +1,235 @@
+# Copyright 2020 Tecnativa - Ernesto Tejeda
+# Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import Form
+
+from .test_rma import TestRma
+
+
+class TestRmaOperation(TestRma):
+    def test_01(self):
+        """
+        ensure that the receipt creation behaves correctly according to the
+        action_create_receipt setting.
+        - "automatic_on_confirm":
+            - receipts are created automatically
+            - the manual button is hidden
+        - "manual_on_confirm"
+            - manual button is visible after confirmation
+            - disappears once a receipt is manually created
+        """
+        self.assertEqual(self.operation.action_create_receipt, "automatic_on_confirm")
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        self.assertFalse(rma.show_create_receipt)
+        rma.action_confirm()
+        self.assertTrue(rma.reception_move_id)
+        self.assertFalse(rma.show_create_receipt)
+        self.operation.action_create_receipt = "manual_on_confirm"
+        rma2 = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        rma2.action_confirm()
+        self.assertTrue(rma2.show_create_receipt)
+        self.assertFalse(rma2.reception_move_id)
+        rma2.action_create_receipt()
+        self.assertFalse(rma2.show_create_receipt)
+
+    def test_02(self):
+        """
+        test delivery button visibility based on operation settings.
+        No deliver possible
+        """
+        self.operation.action_create_delivery = False
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        self.assertFalse(rma.can_be_returned)
+        self.assertFalse(rma.can_be_replaced)
+        rma.action_confirm()
+        self.assertEqual(rma.state, "confirmed")
+        self.assertFalse(rma.can_be_returned)
+        self.assertFalse(rma.show_create_return)
+        self.assertFalse(rma.can_be_replaced)
+        self.assertFalse(rma.show_create_replace)
+
+    def test_03(self):
+        """
+        test delivery button visibility based on operation settings.
+        deliver manually after confirm
+        """
+        self.operation.action_create_delivery = "manual_on_confirm"
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        self.assertFalse(rma.can_be_returned)
+        self.assertFalse(rma.can_be_replaced)
+        rma.action_confirm()
+        self.assertEqual(rma.state, "confirmed")
+        self.assertTrue(rma.can_be_returned)
+        self.assertTrue(rma.show_create_return)
+        self.assertTrue(rma.can_be_replaced)
+        self.assertTrue(rma.show_create_replace)
+
+    def test_04(self):
+        """
+        test delivery button visibility based on operation settings.
+        deliver automatically after confirm, return same product
+        """
+        self.operation.action_create_delivery = "automatic_on_confirm"
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        self.assertFalse(rma.can_be_returned)
+        self.assertFalse(rma.can_be_replaced)
+        rma.action_confirm()
+        self.assertEqual(rma.state, "waiting_return")
+        self.assertFalse(rma.can_be_returned)
+        self.assertFalse(rma.show_create_return)
+        self.assertFalse(rma.can_be_replaced)
+        self.assertFalse(rma.show_create_replace)
+        self.assertTrue(rma.delivery_move_ids)
+        self.assertEqual(rma.delivery_move_ids.product_id, self.product)
+        self.assertEqual(rma.delivery_move_ids.product_uom_qty, 10)
+
+    def test_05(self):
+        """
+        test delivery button visibility based on operation settings.
+        deliver manually after receipt
+        """
+        self.operation.action_create_delivery = "manual_after_receipt"
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        self.assertFalse(rma.can_be_returned)
+        self.assertFalse(rma.can_be_replaced)
+        rma.action_confirm()
+        self.assertEqual(rma.state, "confirmed")
+        self.assertFalse(rma.can_be_returned)
+        self.assertFalse(rma.show_create_return)
+        self.assertFalse(rma.can_be_replaced)
+        self.assertFalse(rma.show_create_replace)
+        rma.reception_move_id.quantity_done = rma.product_uom_qty
+        rma.reception_move_id.picking_id._action_done()
+        self.assertEqual(rma.state, "received")
+        self.assertTrue(rma.can_be_returned)
+        self.assertTrue(rma.show_create_return)
+        self.assertTrue(rma.can_be_replaced)
+        self.assertTrue(rma.show_create_replace)
+
+    def test_06(self):
+        """
+        test delivery button visibility based on operation settings.
+        deliver automatically after receipt
+        """
+        self.operation.action_create_delivery = "automatic_after_receipt"
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        self.assertFalse(rma.can_be_returned)
+        self.assertFalse(rma.can_be_replaced)
+        rma.action_confirm()
+        self.assertEqual(rma.state, "confirmed")
+        self.assertFalse(rma.can_be_returned)
+        self.assertFalse(rma.show_create_return)
+        self.assertFalse(rma.can_be_replaced)
+        self.assertFalse(rma.show_create_replace)
+        self.assertFalse(rma.delivery_move_ids)
+        rma.reception_move_id.quantity_done = rma.product_uom_qty
+        rma.reception_move_id.picking_id._action_done()
+        self.assertEqual(rma.delivery_move_ids.product_id, self.product)
+        self.assertEqual(rma.delivery_move_ids.product_uom_qty, 10)
+        self.assertEqual(rma.state, "waiting_return")
+        self.assertFalse(rma.can_be_returned)
+        self.assertFalse(rma.show_create_return)
+        self.assertFalse(rma.can_be_replaced)
+        self.assertFalse(rma.show_create_replace)
+
+    def test_07(self):
+        """
+        test delivery button visibility based on operation settings.
+        deliver automatically after confirm, different product
+        """
+        self.operation.action_create_delivery = "automatic_on_confirm"
+        self.operation.different_return_product = True
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        with self.assertRaises(AssertionError, msg="Replacement fields are required"):
+            with Form(rma) as rma_form:
+                rma_form.save()
+        with self.assertRaises(
+            ValidationError, msg="Complete the replacement information"
+        ):
+            rma.action_confirm()
+        rma.action_confirm()
+
+    def test_08(self):
+        """test refund, manually after confirm"""
+        self.operation.action_create_refund = "manual_on_confirm"
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        rma.action_confirm()
+        self.assertEqual(rma.state, "confirmed")
+        self.assertTrue(rma.can_be_refunded)
+        self.assertTrue(rma.show_create_refund)
+
+    def test_09(self):
+        """test refund, manually after receipt"""
+        self.operation.action_create_refund = "manual_after_receipt"
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        rma.action_confirm()
+        self.assertEqual(rma.state, "confirmed")
+        self.assertFalse(rma.can_be_refunded)
+        self.assertFalse(rma.show_create_refund)
+        rma.reception_move_id.quantity_done = rma.product_uom_qty
+        rma.reception_move_id.picking_id._action_done()
+        self.assertEqual(rma.state, "received")
+        self.assertTrue(rma.can_be_refunded)
+        self.assertTrue(rma.show_create_refund)
+
+    def test_10(self):
+        """test refund, automatic after confirm"""
+        self.operation.action_create_refund = "automatic_on_confirm"
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        rma.action_confirm()
+        self.assertEqual(rma.state, "refunded")
+        self.assertTrue(rma.refund_id)
+        self.assertFalse(rma.can_be_refunded)
+        self.assertFalse(rma.show_create_refund)
+
+    def test_11(self):
+        """test refund, automatic after confirm"""
+        self.operation.action_create_refund = "automatic_after_receipt"
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        rma.action_confirm()
+        self.assertEqual(rma.state, "confirmed")
+        rma.reception_move_id.quantity_done = rma.product_uom_qty
+        rma.reception_move_id.picking_id._action_done()
+        self.assertEqual(rma.state, "refunded")
+        self.assertTrue(rma.refund_id)
+        self.assertFalse(rma.can_be_refunded)
+        self.assertFalse(rma.show_create_refund)
+
+    def test_12(self):
+        """
+        Refund without product return
+        Some companies may offer refunds without requiring the return of the product,
+        often in cases of low-value items or when the cost of return shipping is
+        prohibitive.
+            - no receipt
+            - no return
+            - automatically refund on confirm
+        """
+        self.operation.action_create_receipt = False
+        self.operation.action_create_refund = "automatic_on_confirm"
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        rma.action_confirm()
+        self.assertEqual(rma.state, "refunded")
+        self.assertFalse(rma.reception_move_id)
+        self.assertTrue(rma.refund_id)
+
+    def test_13(self):
+        """
+        Return of non-ordered product
+        Occasionally, customers receive items they did not order and need a process for
+        returning these products. The delivered product don't figure on the sale order
+        - receipt
+        - no return
+        - no refund
+        """
+        self.operation.action_create_receipt = "automatic_on_confirm"
+        self.operation.action_create_delivery = False
+        self.operation.action_create_refund = False
+        rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        rma.action_confirm()
+        rma.reception_move_id.quantity_done = rma.product_uom_qty
+        rma.reception_move_id.picking_id._action_done()
+        self.assertEqual(rma.state, "received")
+        self.assertFalse(rma.delivery_move_ids)

--- a/rma/tests/test_rma_operation.py
+++ b/rma/tests/test_rma_operation.py
@@ -149,7 +149,13 @@ class TestRmaOperation(TestRma):
             ValidationError, msg="Complete the replacement information"
         ):
             rma.action_confirm()
+        rma.return_product_id = self.product_product.create(
+            {"name": "return Product test 1", "type": "product"}
+        )
         rma.action_confirm()
+        self.assertEqual(rma.delivery_move_ids.product_id, rma.product_id)
+        self.assertEqual(rma.reception_move_id.product_id, rma.return_product_id)
+        self.assertEqual(rma.state, "waiting_return")
 
     def test_08(self):
         """test refund, manually after confirm"""

--- a/rma/tests/test_rma_operation.py
+++ b/rma/tests/test_rma_operation.py
@@ -302,3 +302,16 @@ class TestRmaOperation(TestRma):
         self.assertIn(
             self.warehouse.out_type_id, out_pickings.mapped("picking_type_id")
         )
+
+    def test_16(self):
+        rma = self._create_rma(self.partner, self.product, 1, self.rma_loc)
+        rma.action_confirm()
+        self.assertEqual(rma.reception_move_id.state, "assigned")
+        self.assertEqual(rma.reception_move_id.picking_id.state, "assigned")
+
+    def test_17(self):
+        self.operation.auto_confirm_reception = True
+        rma = self._create_rma(self.partner, self.product, 1, self.rma_loc)
+        rma.action_confirm()
+        self.assertEqual(rma.reception_move_id.state, "done")
+        self.assertEqual(rma.reception_move_id.picking_id.state, "done")

--- a/rma/views/rma_operation.xml
+++ b/rma/views/rma_operation.xml
@@ -17,7 +17,13 @@
                             <field name="action_create_receipt" />
 
                         </group>
-                        <group />
+                        <group>
+                            <field
+                                name="different_return_product"
+                                widget="boolean_toggle"
+                                attrs="{'invisible': [('action_create_receipt', '=', False)]}"
+                            />
+                        </group>
                         <group>
                         <field name="action_create_delivery" />
 

--- a/rma/views/rma_operation.xml
+++ b/rma/views/rma_operation.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 ACSONE SA/NV
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="rma_operation_form_view">
+        <field name="model">rma.operation</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name" />
+                        <field name="active" widget="boolean_toggle" />
+                    </group>
+                    <group string="Settings" name="settings">
+                        <group>
+                            <field name="action_create_receipt" />
+
+                        </group>
+                        <group />
+                        <group>
+                        <field name="action_create_delivery" />
+
+                        </group>
+                        <group />
+                        <group>
+                            <field name="action_create_refund" />
+
+                        </group>
+                        <group />
+
+
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="rma_operation_search_view">
+        <field name="model">rma.operation</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" />
+            </search>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="rma_operation_tree_view">
+        <field name="model">rma.operation</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="action_create_receipt" />
+                <field name="action_create_delivery" />
+                <field name="action_create_refund" />
+                <field name="active" widget="boolean_toggle" />
+            </tree>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="rma_operation_act_window">
+        <field name="name">Operations</field>
+        <field name="res_model">rma.operation</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[]</field>
+        <field name="context">{}</field>
+    </record>
+
+    <record model="ir.ui.menu" id="rma_operation_menu">
+        <field name="name">Operations</field>
+        <field name="parent_id" ref="rma_configuration_menu" />
+        <field name="action" ref="rma_operation_act_window" />
+        <field name="sequence" eval="16" />
+    </record>
+
+</odoo>

--- a/rma/views/rma_operation.xml
+++ b/rma/views/rma_operation.xml
@@ -20,7 +20,10 @@
                         <group>
                             <field
                                 name="different_return_product"
-                                widget="boolean_toggle"
+                                attrs="{'invisible': [('action_create_receipt', '=', False)]}"
+                            />
+                            <field
+                                name="auto_confirm_reception"
                                 attrs="{'invisible': [('action_create_receipt', '=', False)]}"
                             />
                         </group>

--- a/rma/views/rma_views.xml
+++ b/rma/views/rma_views.xml
@@ -290,6 +290,11 @@
                                 force_save="1"
                                 attrs="{'readonly': ['|', ('picking_id', '!=', False), ('state', '!=', 'draft')]}"
                             />
+                            <field
+                                name="return_product_id"
+                                force_save="1"
+                                attrs="{'readonly': ['|', ('picking_id', '!=', False), ('state', '!=', 'draft')], 'invisible': [('different_return_product', '=', False)], 'required': [('different_return_product', '=', True)]}"
+                            />
                             <field name="uom_category_id" invisible="1" />
                             <label for="product_uom_qty" />
                             <div class="o_row">
@@ -370,6 +375,7 @@
                     <field name="show_create_refund" invisible="1" />
                     <field name="show_create_return" invisible="1" />
                     <field name="show_create_replace" invisible="1" />
+                    <field name="different_return_product" invisible="1" />
                     <field name="can_be_split" invisible="1" />
                     <field name="can_be_locked" invisible="1" />
                     <field name="can_be_finished" invisible="1" />

--- a/rma/views/rma_views.xml
+++ b/rma/views/rma_views.xml
@@ -155,24 +155,31 @@
                         class="btn-primary"
                     />
                     <button
+                        name="action_create_receipt"
+                        type="object"
+                        string="Create Receipt"
+                        attrs="{'invisible': [('show_create_receipt', '=', False)]}"
+                        class="btn-primary"
+                    />
+                    <button
                         type="object"
                         string="To Refund"
                         name="action_refund"
-                        attrs="{'invisible': [('can_be_refunded', '=', False)]}"
+                        attrs="{'invisible': [('show_create_refund', '=', False)]}"
                         class="btn-primary"
                     />
                     <button
                         type="object"
                         string="Replace"
                         name="action_replace"
-                        attrs="{'invisible': [('can_be_replaced', '=', False)]}"
+                        attrs="{'invisible': [('show_create_replace', '=', False)]}"
                         class="btn-primary"
                     />
                     <button
                         type="object"
                         string="Return to customer"
                         name="action_return"
-                        attrs="{'invisible': [('can_be_returned', '=', False)]}"
+                        attrs="{'invisible': [('show_create_return', '=', False)]}"
                         class="btn-primary"
                     />
                     <button
@@ -359,9 +366,10 @@
                     <field name="sent" invisible="1" />
                     <field name="reception_move_id" invisible="1" />
                     <field name="refund_id" invisible="1" />
-                    <field name="can_be_refunded" invisible="1" />
-                    <field name="can_be_returned" invisible="1" />
-                    <field name="can_be_replaced" invisible="1" />
+                    <field name="show_create_receipt" invisible="1" />
+                    <field name="show_create_refund" invisible="1" />
+                    <field name="show_create_return" invisible="1" />
+                    <field name="show_create_replace" invisible="1" />
                     <field name="can_be_split" invisible="1" />
                     <field name="can_be_locked" invisible="1" />
                     <field name="can_be_finished" invisible="1" />

--- a/rma/wizard/stock_picking_return.py
+++ b/rma/wizard/stock_picking_return.py
@@ -18,6 +18,14 @@ class ReturnPickingLine(models.TransientModel):
         store=True,
         readonly=False,
     )
+    return_product_id = fields.Many2one(
+        "product.product",
+        help="Product to be returned if it's different from the originally delivered "
+        "item.",
+    )
+    different_return_product = fields.Boolean(
+        related="rma_operation_id.different_return_product"
+    )
 
     @api.depends("wizard_id.rma_operation_id")
     def _compute_rma_operation_id(self):
@@ -34,6 +42,7 @@ class ReturnPickingLine(models.TransientModel):
             "product_uom": self.product_id.uom_id.id,
             "location_id": self.wizard_id.location_id.id or self.move_id.location_id.id,
             "operation_id": self.rma_operation_id.id,
+            "return_product_id": self.return_product_id.id,
         }
 
 

--- a/rma/wizard/stock_picking_return_views.xml
+++ b/rma/wizard/stock_picking_return_views.xml
@@ -13,6 +13,11 @@
                     name="rma_operation_id"
                     attrs="{'column_invisible': [('parent.create_rma', '=', False)], 'required': [('parent.create_rma', '=', True), ('quantity', '>', 0)]}"
                 />
+                <field
+                    name="return_product_id"
+                    attrs="{'column_invisible': [('parent.create_rma', '=', False)], 'invisible': [('different_return_product', '=', False)], 'required': [('different_return_product', '=', True)]}"
+                />
+                    <field name="different_return_product" invisible="1" />
             </xpath>
             <field name="product_return_moves" position="before">
                 <group name="group_rma">

--- a/rma/wizard/stock_picking_return_views.xml
+++ b/rma/wizard/stock_picking_return_views.xml
@@ -15,7 +15,7 @@
                 />
                 <field
                     name="return_product_id"
-                    attrs="{'column_invisible': [('parent.create_rma', '=', False)], 'invisible': [('different_return_product', '=', False)], 'required': [('different_return_product', '=', True)]}"
+                    attrs="{'column_invisible': [('parent.create_rma', '=', False)], 'invisible': [('different_return_product', '=', False)], 'required': [('different_return_product', '=', True), ('quantity', '>', 0)]}"
                 />
                     <field name="different_return_product" invisible="1" />
             </xpath>

--- a/rma_sale/models/rma.py
+++ b/rma_sale/models/rma.py
@@ -186,6 +186,18 @@ class Rma(models.Model):
             vals["sale_line_id"] = self.move_id.sale_line_id.id
         return vals
 
+    def _prepare_replace_procurement_vals(self, warehouse=None, scheduled_date=None):
+        vals = super()._prepare_replace_procurement_vals(
+            warehouse=warehouse, scheduled_date=scheduled_date
+        )
+        if (
+            self.move_id
+            and self.move_id.sale_line_id
+            and self.operation_id.action_create_refund == "update_quantity"
+        ):
+            vals["sale_line_id"] = self.move_id.sale_line_id.id
+        return vals
+
     def _prepare_reception_procurement_vals(self, group=None):
         """This method is used only for reception and a specific RMA IN route."""
         vals = super()._prepare_reception_procurement_vals(group=group)

--- a/rma_sale/models/rma.py
+++ b/rma_sale/models/rma.py
@@ -176,6 +176,27 @@ class Rma(models.Model):
             scheduled_date=scheduled_date, qty=qty, uom=uom
         )
 
+    def _prepare_delivery_procurement_vals(self, scheduled_date=None):
+        vals = super()._prepare_delivery_procurement_vals(scheduled_date=scheduled_date)
+        if (
+            self.move_id
+            and self.move_id.sale_line_id
+            and self.operation_id.action_create_refund == "update_quantity"
+        ):
+            vals["sale_line_id"] = self.move_id.sale_line_id.id
+        return vals
+
+    def _prepare_reception_procurement_vals(self, group=None):
+        """This method is used only for reception and a specific RMA IN route."""
+        vals = super()._prepare_reception_procurement_vals(group=group)
+        if (
+            self.move_id
+            and self.move_id.sale_line_id
+            and self.operation_id.action_create_refund == "update_quantity"
+        ):
+            vals["sale_line_id"] = self.move_id.sale_line_id.id
+        return vals
+
     def create_replace(self, scheduled_date, warehouse, product, qty, uom):
         # When the procurement group has the sale id set it will propagate to the
         # pickings. This is inconvenient for this operation as when we confirm the

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -250,3 +250,47 @@ class TestRmaSale(TestRmaSaleBase):
         res = str(res[0])
         self.assertRegex(res, self.sale_order.name)
         self.assertRegex(res, operation.name)
+
+    def test_manual_refund_no_quantity_impact(self):
+        """If the operation is meant for a manual refund, the delivered quantity
+        should not be updated."""
+        self.operation.action_create_refund = "manual_after_receipt"
+        order = self.sale_order
+        order_line = order.order_line
+        self.assertEqual(order_line.qty_delivered, 5)
+        wizard = self._rma_sale_wizard(order)
+        rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
+        self.assertEqual(rma.reception_move_id.sale_line_id, order_line)
+        rma.action_confirm()
+        rma.reception_move_id.quantity_done = rma.product_uom_qty
+        rma.reception_move_id.picking_id._action_done()
+        self.assertEqual(order.order_line.qty_delivered, 5)
+
+    def test_no_manual_refund_quantity_impact(self):
+        """If the operation is meant for a manual refund, the delivered quantity
+        should not be updated."""
+        self.operation.action_create_refund = "update_quantity"
+        order = self.sale_order
+        order_line = order.order_line
+        self.assertEqual(order_line.qty_delivered, 5)
+        wizard = self._rma_sale_wizard(order)
+        rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
+        self.assertEqual(rma.reception_move_id.sale_line_id, order_line)
+        rma.action_confirm()
+        self.assertFalse(rma.can_be_refunded)
+        rma.reception_move_id.quantity_done = rma.product_uom_qty
+        rma.reception_move_id.picking_id._action_done()
+        self.assertEqual(order.order_line.qty_delivered, 0)
+        delivery_form = Form(
+            self.env["rma.delivery.wizard"].with_context(
+                active_ids=rma.ids,
+                rma_delivery_type="return",
+            )
+        )
+        delivery_form.product_uom_qty = rma.product_uom_qty
+        delivery_wizard = delivery_form.save()
+        delivery_wizard.action_deliver()
+        picking = rma.delivery_move_ids.picking_id
+        picking.move_ids.quantity_done = rma.product_uom_qty
+        picking._action_done()
+        self.assertEqual(order.order_line.qty_delivered, 5)

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -3,6 +3,7 @@
 # Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo.exceptions import ValidationError
 from odoo.tests import Form, tagged
 from odoo.tests.common import users
 
@@ -260,7 +261,7 @@ class TestRmaSale(TestRmaSaleBase):
         self.assertEqual(order_line.qty_delivered, 5)
         wizard = self._rma_sale_wizard(order)
         rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
-        self.assertEqual(rma.reception_move_id.sale_line_id, order_line)
+        self.assertFalse(rma.reception_move_id.sale_line_id)
         rma.action_confirm()
         rma.reception_move_id.quantity_done = rma.product_uom_qty
         rma.reception_move_id.picking_id._action_done()
@@ -276,7 +277,6 @@ class TestRmaSale(TestRmaSaleBase):
         wizard = self._rma_sale_wizard(order)
         rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
         self.assertEqual(rma.reception_move_id.sale_line_id, order_line)
-        rma.action_confirm()
         self.assertFalse(rma.can_be_refunded)
         rma.reception_move_id.quantity_done = rma.product_uom_qty
         rma.reception_move_id.picking_id._action_done()
@@ -293,4 +293,28 @@ class TestRmaSale(TestRmaSaleBase):
         picking = rma.delivery_move_ids.picking_id
         picking.move_ids.quantity_done = rma.product_uom_qty
         picking._action_done()
+        self.assertEqual(order.order_line.qty_delivered, 5)
+
+    def test_return_different_product(self):
+        self.operation.action_create_delivery = False
+        self.operation.different_return_product = True
+        self.operation.action_create_refund = "update_quantity"
+        order = self.sale_order
+        order_line = order.order_line
+        self.assertEqual(order_line.qty_delivered, 5)
+        wizard = self._rma_sale_wizard(order)
+        with self.assertRaises(
+            ValidationError, msg="Complete the replacement information"
+        ):
+            rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
+        return_product = self.product_product.create(
+            {"name": "return Product test 1", "type": "product"}
+        )
+        wizard.line_ids.return_product_id = return_product
+        rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
+        self.assertEqual(rma.reception_move_id.sale_line_id, order_line)
+        self.assertEqual(rma.reception_move_id.product_id, return_product)
+        self.assertFalse(rma.can_be_refunded)
+        rma.reception_move_id.quantity_done = rma.product_uom_qty
+        rma.reception_move_id.picking_id._action_done()
         self.assertEqual(order.order_line.qty_delivered, 5)

--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -157,6 +157,14 @@ class SaleOrderLineRmaWizard(models.TransientModel):
         comodel_name="sale.order.line",
     )
     description = fields.Text()
+    return_product_id = fields.Many2one(
+        "product.product",
+        help="Product to be returned if it's different from the originally delivered "
+        "item.",
+    )
+    different_return_product = fields.Boolean(
+        related="operation_id.different_return_product"
+    )
 
     @api.depends("wizard_id.operation_id")
     def _compute_operation_id(self):
@@ -223,4 +231,5 @@ class SaleOrderLineRmaWizard(models.TransientModel):
             "product_uom": self.uom_id.id,
             "operation_id": self.operation_id.id,
             "description": description,
+            "return_product_id": self.return_product_id.id,
         }

--- a/rma_sale/wizard/sale_order_rma_wizard_views.xml
+++ b/rma_sale/wizard/sale_order_rma_wizard_views.xml
@@ -35,6 +35,11 @@
                                 name="operation_id"
                                 attrs="{'required': [('quantity', '>', 0)]}"
                             />
+                                <field
+                                name="return_product_id"
+                                attrs="{'invisible': [('different_return_product', '=', False)], 'required': [('different_return_product', '=', True)]}"
+                            />
+                            <field name="different_return_product" invisible="1" />
                         </tree>
                     </field>
                 </group>

--- a/rma_sale/wizard/sale_order_rma_wizard_views.xml
+++ b/rma_sale/wizard/sale_order_rma_wizard_views.xml
@@ -37,7 +37,7 @@
                             />
                                 <field
                                 name="return_product_id"
-                                attrs="{'invisible': [('different_return_product', '=', False)], 'required': [('different_return_product', '=', True)]}"
+                                attrs="{'invisible': [('different_return_product', '=', False)], 'required': [('different_return_product', '=', True), ('quantity', '>', 0)]}"
                             />
                             <field name="different_return_product" invisible="1" />
                         </tree>


### PR DESCRIPTION
As explained in #413, having a configurable RMA process helps cover more use cases by allowing the configuration of when the three main actions (reception, delivery, and refund) occur.

This PR adds configuration fields to the RMA operation, which allow managing the visibility of these actions in the RMA form. It also adds the possibility to automatically trigger these actions upon RMA confirmation or reception.

To minimize the impact on current users of this module, default values were set for these settings to maintain the existing workflow unchanged. After making these changes, there was no need to adjust the existing unit tests.

fixes: #413 

cc/ @pedrobaeza , @jbaudoux , @lmignon , @rousseldenis
