### PR TITLE
[16.0][FIX] rma: same procurement group for reception and delivery

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -820,6 +820,7 @@ class Rma(models.Model):
             group = rma.procurement_group_id
             if not group:
                 group = group_model.create(rma._prepare_procurement_group_vals())
+                rma.procurement_group_id = group
             product = self.product_id
             if self.different_return_product:
                 if not self.return_product_id:
@@ -1271,7 +1272,11 @@ class Rma(models.Model):
             key=lambda rma: [rma._delivery_group_key()],
         )
         for _group, rmas in grouped_rmas:
-            rmas = self.browse().concat(*list(rmas))
+            rmas = (
+                self.browse()
+                .concat(*list(rmas))
+                .filtered(lambda rma: not rma.procurement_group_id)
+            )
             if not rmas:
                 continue
             proc_group = self.env["procurement.group"].create(

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -926,3 +926,18 @@ class TestRmaCase(TestRma):
         self.assertEqual(
             rma_1.reception_move_id.picking_id, rma_2.reception_move_id.picking_id
         )
+
+    def test_same_procurement_group_for_reception_and_delivery(self):
+        rma = self._create_confirm_receive(self.partner, self.product, 10, self.rma_loc)
+        self.assertTrue(rma.procurement_group_id)
+        delivery_form = Form(
+            self.env["rma.delivery.wizard"].with_context(
+                active_ids=rma.ids,
+                rma_delivery_type="return",
+            )
+        )
+        delivery_form.product_uom_qty = 2
+        delivery_wizard = delivery_form.save()
+        delivery_wizard.action_deliver()
+        self.assertEqual(rma.delivery_move_ids.group_id, rma.procurement_group_id)
+        self.assertEqual(rma.delivery_move_ids.group_id, rma.reception_move_id.group_id)

--- a/rma_sale/models/rma.py
+++ b/rma_sale/models/rma.py
@@ -164,18 +164,6 @@ class Rma(models.Model):
                 vals["sale_line_ids"] = [(4, line.id)]
         return vals
 
-    def _prepare_procurement_group_vals(self):
-        vals = super()._prepare_procurement_group_vals()
-        if not self.env.context.get("ignore_rma_sale_order") and self.order_id:
-            vals["sale_id"] = self.order_id.id
-        return vals
-
-    def _prepare_delivery_procurements(self, scheduled_date=None, qty=None, uom=None):
-        self = self.with_context(ignore_rma_sale_order=True)
-        return super()._prepare_delivery_procurements(
-            scheduled_date=scheduled_date, qty=qty, uom=uom
-        )
-
     def _prepare_delivery_procurement_vals(self, scheduled_date=None):
         vals = super()._prepare_delivery_procurement_vals(scheduled_date=scheduled_date)
         if (

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -157,10 +157,6 @@ class TestRmaSale(TestRmaSaleBase):
             rma.reception_move_id.origin_returned_move_id,
             self.order_out_picking.move_ids,
         )
-        self.assertEqual(
-            rma.reception_move_id.picking_id + self.order_out_picking,
-            order.picking_ids,
-        )
         user = self.env["res.users"].create(
             {"login": "test_refund_with_so", "name": "Test"}
         )

--- a/rma_sale_mrp/tests/test_rma_sale_mrp.py
+++ b/rma_sale_mrp/tests/test_rma_sale_mrp.py
@@ -98,12 +98,6 @@ class TestRmaSaleMrp(TestRmaSaleBase):
             rma_2.mapped("reception_move_id.origin_returned_move_id"),
             move_2,
         )
-        self.assertEqual(
-            rmas.mapped("reception_move_id.picking_id")
-            + self.order_out_picking
-            + self.backorder,
-            order.picking_ids,
-        )
         # Refund the RMA
         user = self.env["res.users"].create(
             {"login": "test_refund_with_so", "name": "Test"}


### PR DESCRIPTION
The procurement group created for reception was not being correctly assigned to the RMA, resulting in a different group being generated for the delivery.

This fix ensures that the same procurement group is used for both operations.

cc/ @jbaudoux , @lmignon , @rousseldenis 