### PR TITLE
[IMP] rma: custom route for replace action

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -1193,10 +1193,11 @@ class Rma(models.Model):
         rmas_to_return.write({"state": "waiting_return"})
 
     def _prepare_replace_procurement_vals(self, warehouse=None, scheduled_date=None):
-        """This method is used only for Replace (not Delivery). We do not use any
-        specific route here."""
+        """This method is used only for Replace (not Delivery)."""
         vals = self._prepare_common_procurement_vals(warehouse, scheduled_date)
         vals["rma_id"] = self.id
+        if self.warehouse_id.rma_out_replace_route_id:
+            vals["route_ids"] = self.warehouse_id.rma_out_replace_route_id
         return vals
 
     def _prepare_replace_procurements(

--- a/rma/models/stock_warehouse.py
+++ b/rma/models/stock_warehouse.py
@@ -30,6 +30,7 @@ class StockWarehouse(models.Model):
     )
     rma_in_route_id = fields.Many2one("stock.route", "RMA in Route")
     rma_out_route_id = fields.Many2one("stock.route", "RMA out Route")
+    rma_out_replace_route_id = fields.Many2one("stock.route", "RMA out Replace Route")
 
     def _get_rma_location_values(self, vals, code=False):
         """this method is intended to be used by 'create' method

--- a/rma/views/stock_warehouse_views.xml
+++ b/rma/views/stock_warehouse_views.xml
@@ -11,6 +11,10 @@
             <xpath expr="//field[@name='out_type_id']/..">
                 <field name="rma_in_type_id" groups="rma.rma_group_user_own" />
                 <field name="rma_out_type_id" groups="rma.rma_group_user_own" />
+                <field
+                    name="rma_out_replace_route_id"
+                    groups="rma.rma_group_user_own"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
RMA replacement orders currently use the default delivery route, which results in their creation under the default delivery picking type. While this behavior works, it prevents users from tracking RMA replacement orders separately from regular deliveries.

This PR introduces a new field, `rma_out_replace_route_id`, to the warehouse. If set, this field specifies a custom route for RMA replacement actions, allowing users to separate RMA replacement orders from standard deliveries and manage them independently. If the field is not set, the default delivery route will continue to be used.