### PR TITLE
[IMP] rma: add index for rma_id in stock.move model

### DIFF
--- a/rma/models/stock_move.py
+++ b/rma/models/stock_move.py
@@ -26,9 +26,7 @@ class StockMove(models.Model):
     )
     # RMA that creates the out move
     rma_id = fields.Many2one(
-        comodel_name="rma",
-        string="RMA return",
-        copy=False,
+        comodel_name="rma", string="RMA return", copy=False, index=True
     )
 
     def unlink(self):


### PR DESCRIPTION
Add an index to rma_id in the stock.move model to improve access performance for the one2many field delivery_move_ids