### PR TITLE
[IMP] rma: improve rma report layout

### DIFF
--- a/rma/views/report_rma.xml
+++ b/rma/views/report_rma.xml
@@ -95,31 +95,36 @@
                         </p>
                     </div>
                 </div>
-                <div class="row mt32 mb32" id="product_information">
-                    <div t-if="doc.picking_id" class="col-auto mw-100 mb-2">
-                        <strong>Origin delivery:</strong>
-                        <p class="m-0" t-field="doc.picking_id" />
-                    </div>
-                    <div t-if="doc.move_id" class="col-auto mw-100 mb-2">
-                        <strong>Move:</strong>
-                        <p class="m-0" t-field="doc.move_id" />
-                    </div>
-                    <div t-if="doc.product_id" class="col-auto mw-100 mb-2">
-                        <strong>Product:</strong>
-                        <p class="m-0" t-field="doc.product_id" />
-                    </div>
-                    <div t-if="doc.product_id" class="col-auto mw-100 mb-2">
-                        <strong>Quantity:</strong>
-                        <p class="m-0">
-                            <span t-field="doc.product_uom_qty" />
-                            <span t-field="doc.product_uom" groups="uom.group_uom" />
-                        </p>
-                    </div>
-                    <div t-if="doc.delivered_qty" class="col-auto mw-100 mb-2">
-                        <strong>Delivered qty:</strong>
-                        <p class="m-0" t-field="doc.delivered_qty" />
-                    </div>
-                </div>
+                <table class="table table-sm o_main_table table-borderless mt-4">
+                <tbody>
+                  <tr t-if="doc.picking_id" name="tr_picking">
+                    <td>Origin delivery</td>
+                    <td><span t-field="doc.picking_id" /></td>
+                  </tr>
+                  <tr>
+                    <td>Product</td>
+                    <td><span t-field="doc.product_id" /></td>
+                  </tr>
+                  <tr>
+                    <td>Quantity</td>
+                    <td>
+                        <span t-field="doc.product_uom_qty" />
+                        <span t-field="doc.product_uom" groups="uom.group_uom" />
+                    </td>
+                  </tr>
+                  <tr t-if="doc.delivered_qty">
+                    <td>Delivered Quantity</td>
+                    <td>
+                        <span t-field="doc.delivered_qty" />
+                        <span t-field="doc.product_uom" groups="uom.group_uom" />
+                    </td>
+                  </tr>
+                  <tr>
+                      <td>Requested operation</td>
+                      <td><span t-field="doc.operation_id" /></td>
+                  </tr>
+                  </tbody>
+                </table>
                 <div t-if="doc.description">
                     <strong>RMA Note:</strong>
                     <p t-out="doc.description" />

--- a/rma_sale/views/report_rma.xml
+++ b/rma_sale/views/report_rma.xml
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="report_rma_document" inherit_id="rma.report_rma_document">
-        <xpath expr="//div[@t-if='doc.picking_id']" position="before">
-            <div t-if="doc.order_id" class="col-auto mw-100 mb-2">
-                <strong>Sale order:</strong>
-                <p class="m-0" t-field="doc.order_id" />
-            </div>
-        </xpath>
-        <xpath expr="//div[@t-if='doc.user_id']" position="before">
-            <div t-if="doc.operation_id" class="col-auto mw-100 mb-2">
-                <strong>Requested operation:</strong>
-                <p class="m-0" t-field="doc.operation_id" />
-            </div>
+        <xpath expr="//tr[@name='tr_picking']" position="before">
+            <tr t-if="doc.order_id" name="tr_picking">
+                <td>Sale order</td>
+                <td>
+                    <span t-field="doc.order_id" />
+                </td>
+            </tr>
         </xpath>
     </template>
 </odoo>

--- a/rma_sale_mrp/views/report_rma.xml
+++ b/rma_sale_mrp/views/report_rma.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="report_rma_document" inherit_id="rma_sale.report_rma_document">
-        <xpath expr="//div[@id='product_information']" position="after">
+        <xpath expr="//table" position="after">
             <t t-if="doc.sudo().phantom_bom_product">
                 <strong class="d-block mt32 mb-1">Kit information</strong>
                 <div class="row mb32" id="kit_information">


### PR DESCRIPTION
- Use a table instead of a div.
- Remove the move name, as it is not relevant to the customer and is redundant with the SO number and product reference.

**Before**
![image](https://github.com/user-attachments/assets/f65bf4b1-6b01-4150-a829-5f613a64c613)
**After**
![image](https://github.com/user-attachments/assets/dad6112a-1d43-46d0-ac5e-ac9db75328ad)
