### PR TITLE
[16.0][IMP] rma_sale: Avoid computing RMA move unnecessarily

### DIFF
--- a/rma_sale/models/sale.py
+++ b/rma_sale/models/sale.py
@@ -34,6 +34,7 @@ class SaleOrder(models.Model):
             "sale_line_id": data["sale_line_id"].id,
             "uom_id": data["uom"].id,
             "picking_id": data["picking"] and data["picking"].id,
+            "move_id": data.get("move") and data.get("move").id or False,
         }
 
     def action_create_rma(self):
@@ -162,6 +163,7 @@ class SaleOrderLine(models.Model):
                         "uom": move.product_uom,
                         "picking": move.picking_id,
                         "sale_line_id": self,
+                        "move": move,
                     }
                 )
         else:

--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Tecnativa - Ernesto Tejeda
 # Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2024 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import SUPERUSER_ID, _, api, fields, models
@@ -145,7 +146,7 @@ class SaleOrderLineRmaWizard(models.TransientModel):
         string="Delivery order",
         domain="[('id', 'in', allowed_picking_ids)]",
     )
-    move_id = fields.Many2one(comodel_name="stock.move", compute="_compute_move_id")
+    move_id = fields.Many2one(comodel_name="stock.move")
     operation_id = fields.Many2one(
         comodel_name="rma.operation",
         string="Requested operation",
@@ -168,21 +169,6 @@ class SaleOrderLineRmaWizard(models.TransientModel):
     def onchange_product_id(self):
         self.picking_id = False
         self.uom_id = self.product_id.uom_id
-
-    @api.depends("picking_id")
-    def _compute_move_id(self):
-        for record in self:
-            move_id = False
-            if record.picking_id:
-                move_id = record.picking_id.move_ids.filtered(
-                    lambda r: (
-                        r.sale_line_id == record.sale_line_id
-                        and r.sale_line_id.product_id == record.product_id
-                        and r.sale_line_id.order_id == record.order_id
-                        and r.state == "done"
-                    )
-                )
-            record.move_id = move_id
 
     @api.depends("order_id")
     def _compute_allowed_product_ids(self):

--- a/rma_sale/wizard/sale_order_rma_wizard_views.xml
+++ b/rma_sale/wizard/sale_order_rma_wizard_views.xml
@@ -26,6 +26,7 @@
                                 options="{'no_create': True}"
                             />
                             <field name="allowed_picking_ids" invisible="1" />
+                            <field name="move_id" invisible="1" />
                             <field
                                 name="picking_id"
                                 options="{'no_create': True}"

--- a/rma_sale_lot/models/sale_order_line.py
+++ b/rma_sale_lot/models/sale_order_line.py
@@ -20,13 +20,14 @@ class SaleOrderLine(models.Model):
                 ("move_id.scrapped", "=", False),
             ],
             ["qty_done:sum"],
-            ["product_id", "lot_id"],
+            ["product_id", "lot_id", "move_id"],
             lazy=False,
         ):
+            move_id = group.get("move_id")[0] if group.get("move_id") else False
             lot_id = group.get("lot_id")[0] if group.get("lot_id") else False
             product_id = group.get("product_id")[0]
             qty_done = group.get("qty_done")
-            res[(product_id, lot_id)] += qty_done
+            res[(product_id, move_id, lot_id)] += qty_done
         return res
 
     def prepare_sale_rma_data(self):
@@ -38,19 +39,16 @@ class SaleOrderLine(models.Model):
         moves = self.get_delivery_move()
         data = []
         qty_done_by_product_lot = self._get_qty_done_by_product_lot(moves)
-        for (product_id, lot_id), qty_done in qty_done_by_product_lot.items():
+        for (product_id, move_id, lot_id), qty_done in qty_done_by_product_lot.items():
             data.append(
-                self._prepare_sale_rma_data_line(moves, product_id, lot_id, qty_done)
+                self._prepare_sale_rma_data_line(move_id, product_id, lot_id, qty_done)
             )
         return data
 
-    def _prepare_sale_rma_data_line(self, moves, product_id, lot_id, qty_done):
-        moves = moves.move_line_ids.filtered(
-            lambda ml, p_id=product_id, l_id=lot_id: ml.product_id.id == p_id
-            and ml.lot_id.id == l_id
-        ).move_id
+    def _prepare_sale_rma_data_line(self, move_id, product_id, lot_id, qty_done):
+        move = self.env["stock.move"].browse(move_id)
         quantity = qty_done
-        for returned_move in moves.returned_move_ids.filtered(
+        for returned_move in move.returned_move_ids.filtered(
             lambda r: r.state in ["partially_available", "assigned", "done"]
         ):
             if (
@@ -63,13 +61,14 @@ class SaleOrderLine(models.Model):
                 elif returned_move.state == "done":
                     quantity -= returned_move.product_qty
         quantity = float_round(
-            quantity, precision_rounding=moves.product_id.uom_id.rounding
+            quantity, precision_rounding=move.product_id.uom_id.rounding
         )
         return {
-            "product": moves.product_id,
+            "product": move.product_id,
             "quantity": quantity,
-            "uom": moves.product_uom,
-            "picking": moves.picking_id[0],
+            "uom": move.product_uom,
+            "picking": move.picking_id,
             "sale_line_id": self,
             "lot_id": lot_id,
+            "move": move,
         }


### PR DESCRIPTION
In the RMA sale wizard, the move is computed after the wizard line is generated. This is inefficient since the line is created after iterating through the moves related to the sale order.

Assigning the move to the wizard line prevents another issue where all RMAs would be linked to a single move if the sale order line is associated with multiple moves.