### PR TITLE
[17.0][FIX] rma: Add Markup to messages to display the html code correctly + remaining_qty_to_done field

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -306,16 +306,10 @@ class Rma(models.Model):
 
     @api.depends("product_uom_qty", "delivered_qty")
     def _compute_remaining_qty(self):
-        """Compute 'remaining_qty' and 'remaining_qty_to_done' fields.
+        """Compute 'remaining_qty' field.
 
         remaining_qty: is used to set a default quantity of replacing
         or returning of product to the customer.
-
-        remaining_qty_to_done: the aim of this field to control when the
-        RMA cam be set to 'delivered' state. An RMA with
-        remaining_qty_to_done <= 0 can be set to 'delivery'. It is used
-        in stock.move._action_done method of stock.move and
-        rma.extract_quantity.
         """
         for r in self:
             r.remaining_qty = r.product_uom_qty - r.delivered_qty
@@ -380,7 +374,7 @@ class Rma(models.Model):
         for r in self:
             if r.product_uom_qty > 1 and (
                 (r.state == "waiting_return" and r.remaining_qty > 0)
-                or (r.state == "waiting_replacement" and r.remaining_qty_to_done > 0)
+                or (r.state == "waiting_replacement" and r.remaining_qty > 0)
             ):
                 r.can_be_split = True
             else:


### PR DESCRIPTION
Changes done:
- [x] Add Markup to messages to display the html code correctly
- [x] Change `remaining_qty_to_done` to remaining_qty `field` (related to https://github.com/OCA/rma/commit/9cc5bca1532edc9c8de4fd2e0d0a6cb4e0bb8161)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa