### PR TITLE
[17.0][FIX] rma: Allow to download the PDF of the picking from the RMA page

### DIFF
--- a/rma/controllers/main.py
+++ b/rma/controllers/main.py
@@ -125,7 +125,7 @@ class PortalRma(CustomerPortal):
         except exceptions.AccessError:
             return request.redirect("/my")
         report_sudo = request.env.ref("stock.action_report_delivery").sudo()
-        pdf = report_sudo._render_qweb_pdf([picking_sudo.id])[0]
+        pdf = report_sudo._render_qweb_pdf(report_sudo, res_ids=picking_sudo.ids)[0]
         pdfhttpheaders = [
             ("Content-Type", "application/pdf"),
             ("Content-Length", len(pdf)),


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/rma/pull/448

Allow to download the PDF of the picking from the RMA page

Related to https://github.com/OCA/rma/pull/444#pullrequestreview-2615705027

![ejemplo](https://github.com/user-attachments/assets/701d767b-1556-479e-b734-b03c662e0c4c)

@Tecnativa