### PR TITLE
[16.0][FIX] rma_sale: Prevent the close icon from being displayed 2 times

### DIFF
--- a/rma_sale/views/sale_portal_template.xml
+++ b/rma_sale/views/sale_portal_template.xml
@@ -15,7 +15,7 @@
                     class="btn-close"
                     aria-label="Close"
                     data-bs-dismiss="modal"
-                >&amp;times;</button>
+                />
             </header>
             <main
                 t-att-class="not single_page_mode and 'modal-body'"


### PR DESCRIPTION
Prevent the close icon from being displayed 2 times (related to https://github.com/OCA/rma/pull/452#discussion_r1964995678)

![ejemplo](https://github.com/user-attachments/assets/8d8434d2-7e6c-4a5a-b591-403cbcd75fec)

Please @pedrobaeza can you review it?

@Tencativa TT52353