### PR TITLE
[16.0][FIX] rma_sale: replacements create order lines

### DIFF
--- a/rma_sale/README.rst
+++ b/rma_sale/README.rst
@@ -120,13 +120,13 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-.. |maintainer-chienandalu| image:: https://github.com/chienandalu.png?size=40px
-    :target: https://github.com/chienandalu
-    :alt: chienandalu
+.. |maintainer-pedrobaeza| image:: https://github.com/pedrobaeza.png?size=40px
+    :target: https://github.com/pedrobaeza
+    :alt: pedrobaeza
 
 Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-chienandalu| 
+|maintainer-pedrobaeza| 
 
 This module is part of the `OCA/rma <https://github.com/OCA/rma/tree/16.0/rma_sale>`_ project on GitHub.
 

--- a/rma_sale/__manifest__.py
+++ b/rma_sale/__manifest__.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Tecnativa - Ernesto Tejeda
 # Copyright 2022-2023 Tecnativa - Víctor Martínez
 # Copyright 2021-2023 Tecnativa - David Vidal
-# Copyright 2021-2023 Tecnativa - Pedro M. Baeza
+# Copyright 2021,2023,2025 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Return Merchandise Authorization Management - Link with Sales",
@@ -11,7 +11,7 @@
     "category": "RMA",
     "website": "https://github.com/OCA/rma",
     "author": "Tecnativa, Odoo Community Association (OCA)",
-    "maintainers": ["chienandalu"],
+    "maintainers": ["pedrobaeza"],
     "license": "AGPL-3",
     "depends": ["rma", "sale_stock"],
     "data": [

--- a/rma_sale/models/rma.py
+++ b/rma_sale/models/rma.py
@@ -175,3 +175,14 @@ class Rma(models.Model):
         return super()._prepare_delivery_procurements(
             scheduled_date=scheduled_date, qty=qty, uom=uom
         )
+
+    def create_replace(self, scheduled_date, warehouse, product, qty, uom):
+        # When the procurement group has the sale id set it will propagate to the
+        # pickings. This is inconvenient for this operation as when we confirm the
+        # customer delivery a new order line will be created with the replaced option
+        # which will be set for invoicing.
+        moves_before = self.delivery_move_ids
+        res = super().create_replace(scheduled_date, warehouse, product, qty, uom)
+        new_moves = self.delivery_move_ids - moves_before
+        new_moves.picking_id.sale_id = False
+        return res

--- a/rma_sale/static/description/index.html
+++ b/rma_sale/static/description/index.html
@@ -467,7 +467,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
 <p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/chienandalu"><img alt="chienandalu" src="https://github.com/chienandalu.png?size=40px" /></a></p>
+<p><a class="reference external image-reference" href="https://github.com/pedrobaeza"><img alt="pedrobaeza" src="https://github.com/pedrobaeza.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/rma/tree/16.0/rma_sale">OCA/rma</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -116,6 +116,22 @@ class TestRmaSale(TestRmaSaleBase):
         rma.action_confirm()
         self.assertTrue(rma.reception_move_id)
         self.assertFalse(rma.reception_move_id.origin_returned_move_id)
+        # Receive the product
+        rma.reception_move_id.quantity_done = rma.product_uom_qty
+        rma.reception_move_id.picking_id._action_done()
+        # Now do a replacement for testing the issue of a new SO line created for P2
+        delivery_form = Form(
+            self.env["rma.delivery.wizard"].with_context(
+                active_ids=rma.ids, rma_delivery_type="replace"
+            )
+        )
+        delivery_form.product_id = self.product_2
+        delivery_form.product_uom_qty = 5
+        delivery_wizard = delivery_form.save()
+        delivery_wizard.action_deliver()
+        rma.delivery_move_ids.quantity_done = rma.product_uom_qty
+        rma.delivery_move_ids.picking_id._action_done()
+        self.assertEqual(len(self.sale_order.order_line), 1)
 
     def test_create_rma_from_so(self):
         order = self.sale_order


### PR DESCRIPTION
When the RMA procurement group has a sale set it will propagate to the pickings. This is inconvenient for this operation as when we confirm the customer delivery a new order line will be created with the replaced option which will be set for invoicing.

cc @Tecnativa TT55461

Not sure about the fix though, as it could be argumented that the replacement could be invoiced with a price of 0 or whatever difference the user considers at the moment. In any case, 

This is the relevant core code: https://github.com/odoo/odoo/blob/b1d88c20a6cf2a2f283ed04f145cb9e7fc614755/addons/sale_stock/models/stock.py#L85-L117

In the other hand if there were automatic invoicing processes, wrong invoices would be sent to customers, causing confussions...


Opinions? @sbejaoui @pedrobaeza @victoralmau 