### PR TITLE
[17.0][IMP]rma :add customer search field in search view

### DIFF
--- a/rma/views/rma_views.xml
+++ b/rma/views/rma_views.xml
@@ -13,6 +13,7 @@
                 <field name="user_id" />
                 <field name="product_id" />
                 <field name="tag_ids" />
+                <field name="partner_id" />
                 <filter
                     string="Awaiting Action"
                     name="waiting_action"


### PR DESCRIPTION
@HaraldPanten @ValentinVinagre  @luis-ron 
Added ‘partner_id’ field in the ‘rma_view_search’ search view to allow filtering RMAs by Customer, according to the requested functionality. Existing filters and grouping logic were not modified.
[T-8709]