### PR TITLE
[16.0][IMP] rma: Allow manual finish of confirmed RMAs with no further processing required

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -337,6 +337,24 @@ class Rma(models.Model):
     different_return_product = fields.Boolean(
         related="operation_id.different_return_product"
     )
+    requires_action = fields.Boolean(
+        compute="_compute_requires_action",
+        help="Indicates whether the RMA requires processing such as a receipt,"
+        "delivery, or refund.",
+    )
+
+    @api.depends("operation_id")
+    def _compute_requires_action(self):
+        """
+        compute whether the RMA requires any follow-up action based on the
+        operation configuration
+        """
+        for rma in self:
+            rma.requires_action = (
+                rma.operation_id.action_create_receipt
+                or rma.operation_id.action_create_delivery
+                or rma.operation_id.action_create_refund
+            )
 
     @api.depends("operation_id.action_create_receipt", "state", "reception_move_id")
     def _compute_show_create_receipt(self):
@@ -509,13 +527,17 @@ class Rma(models.Model):
                 and r.state == "confirmed"
             )
 
-    @api.depends("state", "remaining_qty")
+    @api.depends("state", "remaining_qty", "requires_action")
     def _compute_can_be_finished(self):
+        # The RMA can be finished if:
+        # - It's in a transitional state AND there is still quantity to process
+        # OR
+        # - It's not already finished AND no further action is required
         for rma in self:
             rma.can_be_finished = (
                 rma.state in {"received", "waiting_replacement", "waiting_return"}
                 and rma.remaining_qty > 0
-            )
+            ) or (rma.state != "finished" and not rma.requires_action)
 
     @api.depends("product_uom_qty", "state", "remaining_qty", "remaining_qty_to_done")
     def _compute_can_be_split(self):
@@ -960,6 +982,9 @@ class Rma(models.Model):
     def action_finish(self):
         """Invoked when a user wants to manually finalize the RMA"""
         self.ensure_one()
+        if not self.requires_action:
+            self.state = "finished"
+            return {}
         self._ensure_can_be_returned()
         # Force active_id to avoid issues when coming from smart buttons
         # in other models

--- a/rma/tests/test_rma_operation.py
+++ b/rma/tests/test_rma_operation.py
@@ -315,3 +315,21 @@ class TestRmaOperation(TestRma):
         rma.action_confirm()
         self.assertEqual(rma.reception_move_id.state, "done")
         self.assertEqual(rma.reception_move_id.picking_id.state, "done")
+
+    def test_manual_finish_if_no_required_action_flag(self):
+        self.operation.action_create_receipt = False
+        self.operation.action_create_delivery = False
+        self.operation.action_create_refund = False
+        rma = self._create_rma(self.partner, self.product, 1, self.rma_loc)
+        rma.action_confirm()
+        self.assertFalse(rma.requires_action)
+        self.assertEqual(rma.state, "confirmed")
+        rma.action_finish()
+        self.assertEqual(rma.state, "finished")
+        self.operation.action_create_receipt = "manual_on_confirm"
+        rma2 = self._create_rma(self.partner, self.product, 1, self.rma_loc)
+        rma2.action_confirm()
+        self.assertTrue(rma2.requires_action)
+        self.assertEqual(rma2.state, "confirmed")
+        with self.assertRaises(ValidationError):
+            rma2.action_finish()


### PR DESCRIPTION
I came with a special case: a product was delivered by mistake but isn’t worth returning and can’t be invoiced. The operation is configured to prevent any further action (no receipt, no delivery, no refund). The goal is to track the case through an RMA, but still allow the user to close it manually when no follow-up is needed.

This PR enables users to manually finish RMAs after confirmation in such cases

cc/ @pedrobaeza , @rousseldenis , @lmignon 