### PR TITLE
[16.0][FIX] rma: add access read to stock user

### DIFF
--- a/rma/security/ir.model.access.csv
+++ b/rma/security/ir.model.access.csv
@@ -2,6 +2,7 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_rma_team_user_own,rma.team.user.own,model_rma_team,rma_group_user_own,1,0,0,0
 access_rma_team_manager,rma.team.manager,model_rma_team,rma_group_manager,1,1,1,1
 access_rma_portal,rma.portal,model_rma,base.group_portal,1,0,0,0
+access_rma_stock,rma.stock,model_rma,stock.group_stock_user,1,0,0,0
 access_rma_user_own,rma.user.own,model_rma,rma_group_user_own,1,1,1,0
 access_rma_manager,rma.manager,model_rma,rma_group_manager,1,1,1,1
 access_rma_operation_user_own,rma.operation.user.own,model_rma_operation,rma_group_user_own,1,0,0,0

--- a/rma/views/menus.xml
+++ b/rma/views/menus.xml
@@ -2,7 +2,12 @@
 <!-- Copyright 2020 Tecnativa - Ernesto Tejeda
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
-    <menuitem id="rma_menu" name="RMA" web_icon="rma,static/description/icon.png" />
+    <menuitem
+        id="rma_menu"
+        name="RMA"
+        web_icon="rma,static/description/icon.png"
+        groups="rma.rma_group_user_own"
+    />
     <menuitem id="rma_orders_menu" parent="rma_menu" name="Orders" sequence="10" />
     <menuitem
         id="rma_reporting_menu"


### PR DESCRIPTION
The rma_receiver_ids field is is in the list of fields for moves merge, which requires read access to the rma model.
This PR adds read access to stock users, preventing access errors during move merging

