### PR TITLE
[16.0][IMP] rma_lot: option to deliver same lot/serial as received

### DIFF
--- a/rma_lot/README.rst
+++ b/rma_lot/README.rst
@@ -50,6 +50,16 @@ during a return and that inventory records remain accurate.
 .. contents::
    :local:
 
+Configuration
+=============
+
+To allow delivering or replacing with the **same lot/serial** received
+from the customer:
+
+1. Go to **RMA ▸ Configuration ▸ Operations**.
+2. Open or create an operation.
+3. Enable **Deliver Same Lot/Serial as Received**.
+
 Bug Tracker
 ===========
 

--- a/rma_lot/__manifest__.py
+++ b/rma_lot/__manifest__.py
@@ -10,6 +10,6 @@
     "author": "ACSONE SA/NV,BCIM,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/rma",
     "depends": ["rma", "stock_picking_return_lot"],
-    "data": ["views/rma.xml"],
+    "data": ["views/rma_operation.xml", "views/rma.xml"],
     "demo": [],
 }

--- a/rma_lot/models/__init__.py
+++ b/rma_lot/models/__init__.py
@@ -1,1 +1,2 @@
 from . import rma
+from . import rma_operation

--- a/rma_lot/models/rma.py
+++ b/rma_lot/models/rma.py
@@ -28,6 +28,16 @@ class Rma(models.Model):
         vals["restrict_lot_id"] = self.lot_id.id
         return vals
 
+    def _prepare_common_procurement_vals(
+        self, warehouse=None, scheduled_date=None, group=None
+    ):
+        vals = super()._prepare_common_procurement_vals(
+            warehouse=warehouse, scheduled_date=scheduled_date, group=group
+        )
+        if self.operation_id.deliver_same_lot:
+            vals["restrict_lot_id"] = self.lot_id.id
+        return vals
+
     @api.depends("move_id", "lot_id")
     def _compute_product_id(self):
         res = super()._compute_product_id()

--- a/rma_lot/models/rma_operation.py
+++ b/rma_lot/models/rma_operation.py
@@ -1,0 +1,16 @@
+# Copyright 2025 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class RmaOperation(models.Model):
+
+    _inherit = "rma.operation"
+
+    deliver_same_lot = fields.Boolean(
+        string="Deliver Same Lot/Serial as Received",
+        help="If enabled, the replacement or delivery product will use the exact "
+        "lot/serial number received from the customer. Disable if a different "
+        "lot or serial number should be assigned.",
+    )

--- a/rma_lot/readme/CONFIGURE.md
+++ b/rma_lot/readme/CONFIGURE.md
@@ -1,0 +1,5 @@
+To allow delivering or replacing with the **same lot/serial** received from the customer:
+
+1. Go to **RMA ▸ Configuration ▸ Operations**.
+2. Open or create an operation.
+3. Enable **Deliver Same Lot/Serial as Received**.

--- a/rma_lot/static/description/index.html
+++ b/rma_lot/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -386,17 +387,28 @@ during a return and that inventory records remain accurate.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-5">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<p>To allow delivering or replacing with the <strong>same lot/serial</strong> received
+from the customer:</p>
+<ol class="arabic simple">
+<li>Go to <strong>RMA ▸ Configuration ▸ Operations</strong>.</li>
+<li>Open or create an operation.</li>
+<li>Enable <strong>Deliver Same Lot/Serial as Received</strong>.</li>
+</ol>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/rma/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -404,25 +416,27 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-2">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-3">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
 <ul class="simple">
 <li>ACSONE SA/NV</li>
 <li>BCIM</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
 <ul class="simple">
 <li>Jacques-Etienne Baudoux - BCIM <a class="reference external" href="mailto:je&#64;bcim.be">je&#64;bcim.be</a></li>
 <li>Souheil Bejaoui - ACSONE SA/NV <a class="reference external" href="mailto:souheil.bejaoui&#64;acsone.eu">souheil.bejaoui&#64;acsone.eu</a></li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/rma_lot/tests/test_rma_lot.py
+++ b/rma_lot/tests/test_rma_lot.py
@@ -54,6 +54,7 @@ class TestRMALot(TransactionCase):
         cls.picking.action_set_quantities_to_reservation()
         cls.picking._action_done()
         cls.operation = cls.env.ref("rma.rma_operation_replace")
+        cls.operation.action_create_delivery = "automatic_on_confirm"
 
     @classmethod
     def create_return_wiz(cls):
@@ -93,6 +94,7 @@ class TestRMALot(TransactionCase):
         self.assertEqual(rma_lot_2.reception_move_id.restrict_lot_id, self.lot_2)
         self.assertEqual(rma_lot_2.reception_move_id.state, "assigned")
         self.assertEqual(rma_lot_2.reception_move_id.move_line_ids.lot_id, self.lot_2)
+        return rma_lot_1, rma_lot_2
 
     def test_rma_form(self):
         rma_form = Form(self.env["rma"])
@@ -101,3 +103,15 @@ class TestRMALot(TransactionCase):
         self.assertEqual(rma_form.product_id, self.product)
         rma_form.product_id = self.env.ref("product.product_product_4")
         self.assertFalse(rma_form.lot_id)
+
+    def test_deliver_same_lot_as_received(self):
+        self.operation.deliver_same_lot = True
+        rma_lot_1, rma_lot_2 = self.test_00()
+        self.assertEqual(rma_lot_1.delivery_move_ids.restrict_lot_id, self.lot_1)
+        self.assertEqual(rma_lot_2.delivery_move_ids.restrict_lot_id, self.lot_2)
+
+    def test_deliver_different_lot_as_received(self):
+        self.operation.deliver_same_lot = False
+        rma_lot_1, rma_lot_2 = self.test_00()
+        self.assertFalse(rma_lot_1.delivery_move_ids.restrict_lot_id)
+        self.assertFalse(rma_lot_2.delivery_move_ids.restrict_lot_id, self.lot_2)

--- a/rma_lot/views/rma_operation.xml
+++ b/rma_lot/views/rma_operation.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 ACSONE SA/NV
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="rma_operation_form_view">
+        <field name="model">rma.operation</field>
+        <field name="inherit_id" ref="rma.rma_operation_form_view" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='action_create_delivery']//parent::group/following-sibling::group[1]"
+                position="inside"
+            >
+                <field
+                    name="deliver_same_lot"
+                    attrs="{'invisible': [('action_create_delivery', '=', False)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+
+
+</odoo>


### PR DESCRIPTION
Add bool field `same_lot_as_received` on RMA operations to allow delivering or replacing with the exact lot/serial received from the customer. Useful for returning the same physical unit or a repaired item.