### PR TITLE
[IMP] rma: allow manual finishing for reception-only operations

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -337,21 +337,25 @@ class Rma(models.Model):
     different_return_product = fields.Boolean(
         related="operation_id.different_return_product"
     )
-    requires_action = fields.Boolean(
-        compute="_compute_requires_action",
-        help="Indicates whether the RMA requires processing such as a receipt,"
+    manual_finish_allowed = fields.Boolean(
+        compute="_compute_manual_finish_allowed",
+        help="Indicates whether this RMA can be manually finished, "
+        "without requiring further processing such as a receipt, "
         "delivery, or refund.",
     )
 
-    @api.depends("operation_id")
-    def _compute_requires_action(self):
+    @api.depends("operation_id", "reception_move_id.state")
+    def _compute_manual_finish_allowed(self):
         """
         compute whether the RMA requires any follow-up action based on the
         operation configuration
         """
         for rma in self:
-            rma.requires_action = (
-                rma.operation_id.action_create_receipt
+            rma.manual_finish_allowed = (
+                (
+                    rma.operation_id.action_create_receipt
+                    and rma.reception_move_id.state != "done"
+                )
                 or rma.operation_id.action_create_delivery
                 or rma.operation_id.action_create_refund
             )
@@ -527,7 +531,7 @@ class Rma(models.Model):
                 and r.state == "confirmed"
             )
 
-    @api.depends("state", "remaining_qty", "requires_action")
+    @api.depends("state", "remaining_qty", "manual_finish_allowed")
     def _compute_can_be_finished(self):
         # The RMA can be finished if:
         # - It's in a transitional state AND there is still quantity to process
@@ -537,7 +541,7 @@ class Rma(models.Model):
             rma.can_be_finished = (
                 rma.state in {"received", "waiting_replacement", "waiting_return"}
                 and rma.remaining_qty > 0
-            ) or (rma.state != "finished" and not rma.requires_action)
+            ) or (rma.state != "finished" and not rma.manual_finish_allowed)
 
     @api.depends("product_uom_qty", "state", "remaining_qty", "remaining_qty_to_done")
     def _compute_can_be_split(self):
@@ -982,9 +986,16 @@ class Rma(models.Model):
     def action_finish(self):
         """Invoked when a user wants to manually finalize the RMA"""
         self.ensure_one()
-        if not self.requires_action:
+        if not self.manual_finish_allowed:
             self.state = "finished"
             return {}
+        if (
+            self.operation_id.action_create_receipt
+            and self.reception_move_id.state != "done"
+        ):
+            raise ValidationError(
+                _("The reception must be done before finishing this rma")
+            )
         self._ensure_can_be_returned()
         # Force active_id to avoid issues when coming from smart buttons
         # in other models

--- a/rma/tests/test_rma_operation.py
+++ b/rma/tests/test_rma_operation.py
@@ -322,14 +322,33 @@ class TestRmaOperation(TestRma):
         self.operation.action_create_refund = False
         rma = self._create_rma(self.partner, self.product, 1, self.rma_loc)
         rma.action_confirm()
-        self.assertFalse(rma.requires_action)
+        self.assertFalse(rma.manual_finish_allowed)
         self.assertEqual(rma.state, "confirmed")
         rma.action_finish()
         self.assertEqual(rma.state, "finished")
         self.operation.action_create_receipt = "manual_on_confirm"
         rma2 = self._create_rma(self.partner, self.product, 1, self.rma_loc)
         rma2.action_confirm()
-        self.assertTrue(rma2.requires_action)
+        self.assertTrue(rma2.manual_finish_allowed)
         self.assertEqual(rma2.state, "confirmed")
         with self.assertRaises(ValidationError):
             rma2.action_finish()
+
+    def test_manual_finish_if_required_actions_are_done(self):
+        self.operation.action_create_receipt = "automatic_on_confirm"
+        self.operation.action_create_delivery = False
+        self.operation.action_create_refund = False
+        rma = self._create_rma(self.partner, self.product, 1, self.rma_loc)
+        rma.action_confirm()
+        self.assertTrue(rma.manual_finish_allowed)
+        self.assertEqual(rma.state, "confirmed")
+        with self.assertRaisesRegex(
+            ValidationError, "The reception must be done before finishing this rma"
+        ):
+            rma.action_finish()
+        rma.reception_move_id.quantity_done = rma.product_uom_qty
+        rma.reception_move_id.picking_id._action_done()
+        self.assertFalse(rma.manual_finish_allowed)
+        self.assertEqual(rma.reception_move_id.state, "done")
+        rma.action_finish()
+        self.assertEqual(rma.state, "finished")


### PR DESCRIPTION
in the same spirit of #464, this PR allows RMAs with operations requiring only reception to be manually marked as finished, this avoids leaving them in an intermediate state when no further steps (refund, replacement, delivery) are needed