### PR TITLE
[18.0][FIX] rma_sale: Can create from multiple products

### DIFF
--- a/rma_sale/wizard/sale_order_rma_wizard.py
+++ b/rma_sale/wizard/sale_order_rma_wizard.py
@@ -67,7 +67,8 @@ class SaleOrderRmaWizard(models.TransientModel):
         )
         rma = rma_model.create(val_list)
         if from_portal:
-            rma._add_message_subscribe_partner()
+            for r in rma:
+                r._add_message_subscribe_partner()
         # post messages
         msg_list = [
             '<a href="#" data-oe-model="rma" data-oe-id="%d">%s</a>' % (r.id, r.name)


### PR DESCRIPTION
If you want to create multiple RMAs for multiple products at the same time, you cannot; the system shows you the following error. 

This solution allows you to create RMAs for one or several products at the same time without any issues.


<img width="1920" height="813" alt="image" src="https://github.com/user-attachments/assets/604754a6-1fb8-4751-8e40-8483b744cb30" />


<img width="1920" height="813" alt="image" src="https://github.com/user-attachments/assets/3196d367-4915-4350-85d5-bd9369d638db" />


<img width="1920" height="1010" alt="image" src="https://github.com/user-attachments/assets/9cbf3faf-c0c4-4041-b346-8439ce73fbbb" />
