### PR TITLE
[18.0][FIX] rma: Do not display the company_id field multiple times in the finalization and make the view editable

### DIFF
--- a/rma/views/rma_finalization_views.xml
+++ b/rma/views/rma_finalization_views.xml
@@ -45,10 +45,9 @@
         <field name="model">rma.finalization</field>
         <field eval="6" name="priority" />
         <field name="arch" type="xml">
-            <list>
+            <list editable="bottom">
                 <field name="name" />
                 <field name="company_id" groups="base.group_multi_company" />
-                <field name="company_id" invisible="1" />
             </list>
         </field>
     </record>


### PR DESCRIPTION
Do not display the `company_id` field multiple times in the finalization and make the view editable.

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT57139