### PR TITLE
[18.0][FIX] rma: Do not display the finalization field if the user does not have the appropriate permission

### DIFF
--- a/rma/views/rma_views.xml
+++ b/rma/views/rma_views.xml
@@ -118,7 +118,11 @@
                 <field name="product_uom" groups="uom.group_uom" />
                 <field name="date" />
                 <field name="deadline" />
-                <field name="finalization_id" optional="hide" />
+                <field
+                    name="finalization_id"
+                    optional="hide"
+                    groups="rma.group_rma_manual_finalization"
+                />
                 <field name="state" />
             </list>
         </field>


### PR DESCRIPTION
Do not display the finalization field if the user does not have the appropriate permission

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT57139