### PR TITLE
[17.0][IMP] rma: Display the Configuration menu only to users with Manager permission

### DIFF
--- a/rma/views/menus.xml
+++ b/rma/views/menus.xml
@@ -12,6 +12,7 @@
     />
     <menuitem
         id="rma_configuration_menu"
+        groups="rma_group_manager"
         parent="rma_menu"
         name="Configuration"
         sequence="30"


### PR DESCRIPTION
Backport from 18.0: https://github.com/OCA/rma/pull/509

Display the Configuration menu only to users with Manager permission

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT57139