### PR TITLE
[16.0][IMP] rma : send receipt notification when receiving product in waiting_replacement state 

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -344,6 +344,7 @@ class Rma(models.Model):
         "without requiring further processing such as a receipt, "
         "delivery, or refund.",
     )
+    receipt_confirmation_email_sent = fields.Boolean(default=False)
 
     @api.depends("operation_id", "reception_move_id.state")
     def _compute_manual_finish_allowed(self):
@@ -741,6 +742,7 @@ class Rma(models.Model):
                 mark_rma_as_sent=True,
                 default_subtype_id=self.env.ref("rma.mt_rma_notification").id,
             ).message_post_with_template(rma_template_id)
+            rma.receipt_confirmation_email_sent = True
 
     # Action methods
     def action_rma_send(self):
@@ -1561,7 +1563,7 @@ class Rma(models.Model):
         Here we can attach methods to trigger when the customer products
         are received on the RMA location, such as automatic notifications
         """
-        self.write({"state": "received"})
+        self.filtered(lambda r: r.state == "confirmed").write({"state": "received"})
         self._send_receipt_confirmation_email()
         for rec in self:
             if rec.operation_id.action_create_delivery == "automatic_after_receipt":

--- a/rma/models/stock_move.py
+++ b/rma/models/stock_move.py
@@ -88,12 +88,8 @@ class StockMove(models.Model):
         move_done = self.filtered(lambda r: r.state == "done").sudo()
         # Set RMAs as received. We sudo so we can grant the operation even
         # if the stock user has no RMA permissions.
-        to_be_received = (
-            move_done.sudo()
-            .mapped("rma_receiver_ids")
-            .filtered(lambda r: r.state == "confirmed")
-        )
-        to_be_received.update_received_state_on_reception()
+
+        move_done.mapped("rma_receiver_ids").update_received_state_on_reception()
         # Set RMAs as delivered
         move_done.mapped("rma_id").update_replaced_state()
         move_done.mapped("rma_id").update_returned_state()

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -985,3 +985,14 @@ class TestRmaCase(TestRma):
         self.assertNotEqual(rma1.procurement_group_id, rma3.procurement_group_id)
         self.assertEqual(len((rma1 | rma2).reception_move_id.picking_id), 1)
         self.assertEqual(len((rma1 | rma2 | rma3).reception_move_id.picking_id), 2)
+
+    def test_send_rma_receipt_notification(self):
+        self.env.company.send_rma_receipt_confirmation = True
+        self.operation.action_create_receipt = "automatic_on_confirm"
+        self.operation.action_create_delivery = "automatic_on_confirm"
+        self.partner.email = "partner@email.com"
+        rma = self._create_confirm_receive(
+            self.partner, self.product, 1, self.rma_loc, self.operation
+        )
+        self.assertTrue(rma.state, "waiting_replacement")
+        self.assertTrue(rma.receipt_confirmation_email_sent)


### PR DESCRIPTION
This improvement ensures that the receipt notification email is sent to the customer when a product is received for an RMA that is already in the waiting_replacement state.

**Problem:**
When an RMA operation is configured to create the delivery order automatically on confirmation, the RMA moves directly to the waiting_replacement state without passing through the received state, because the delivery order is created immediately. As a result, when the product is later received, the receipt notification email is not sent to the customer. 