### PR TITLE
[18.0][IMP] rma + rma_reason: Remove the RMA text from some menus as it is redundant

### DIFF
--- a/rma/i18n/de.po
+++ b/rma/i18n/de.po
@@ -713,8 +713,8 @@ msgstr "Erstellen Sie einen neuen RMA-Abschluss"
 
 #. module: rma
 #: model_terms:ir.actions.act_window,help:rma.action_rma_tag
-msgid "Create a new RMA tag"
-msgstr "Erstellen Sie ein neues RMA-Tag"
+msgid "Create a new tag"
+msgstr "Erstellen Sie ein neues Tag"
 
 #. module: rma
 #: model:ir.model.fields,field_description:rma.field_rma__create_uid
@@ -1221,9 +1221,9 @@ msgstr ""
 #. module: rma
 #: model_terms:ir.actions.act_window,help:rma.action_rma_tag
 msgid ""
-"Manage RMA tags to better classify them for tracking and analysis purposes."
+"Manage tags to better classify them for tracking and analysis purposes."
 msgstr ""
-"Verwalten Sie RMA-Tags, um sie für Nachverfolgungs- und Analysezwecke besser "
+"Verwalten Sie Tags, um sie für Nachverfolgungs- und Analysezwecke besser "
 "zu klassifizieren."
 
 #. module: rma
@@ -1694,8 +1694,8 @@ msgstr "RMA-Tags"
 #: model:ir.model.fields,field_description:rma.field_res_users__rma_team_id
 #: model:ir.ui.menu,name:rma.rma_configuration_rma_team_menu
 #: model_terms:ir.ui.view,arch_db:rma.rma_team_view_form
-msgid "RMA Team"
-msgstr "RMA-Team"
+msgid "Teams"
+msgstr "Teams"
 
 #. module: rma
 #: model:ir.model.fields,help:rma.field_res_users__rma_team_id

--- a/rma/i18n/de_AT.po
+++ b/rma/i18n/de_AT.po
@@ -1632,7 +1632,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:rma.field_res_users__rma_team_id
 #: model:ir.ui.menu,name:rma.rma_configuration_rma_team_menu
 #: model_terms:ir.ui.view,arch_db:rma.rma_team_view_form
-msgid "RMA Team"
+msgid "Teams"
 msgstr ""
 
 #. module: rma

--- a/rma/i18n/es.po
+++ b/rma/i18n/es.po
@@ -806,8 +806,8 @@ msgstr "Crear un nuevo motivo de finalización de RMA"
 
 #. module: rma
 #: model_terms:ir.actions.act_window,help:rma.action_rma_tag
-msgid "Create a new RMA tag"
-msgstr "Crear una nueva etiqueta de RMA"
+msgid "Create a new tag"
+msgstr "Crear una nueva etiqueta"
 
 #. module: rma
 #: model:ir.model.fields,field_description:rma.field_rma__create_uid
@@ -1322,9 +1322,9 @@ msgstr ""
 #. module: rma
 #: model_terms:ir.actions.act_window,help:rma.action_rma_tag
 msgid ""
-"Manage RMA tags to better classify them for tracking and analysis purposes."
+"Manage tags to better classify them for tracking and analysis purposes."
 msgstr ""
-"Administrar etiquetas de RMA para clasificarlos de modo que mejore el "
+"Administrar etiquetas para clasificarlos de modo que mejore el "
 "seguimiento y análisis de los mismos."
 
 #. module: rma
@@ -1797,8 +1797,8 @@ msgstr "Etiquetas RMA"
 #: model:ir.model.fields,field_description:rma.field_res_users__rma_team_id
 #: model:ir.ui.menu,name:rma.rma_configuration_rma_team_menu
 #: model_terms:ir.ui.view,arch_db:rma.rma_team_view_form
-msgid "RMA Team"
-msgstr "Equipo de RMA"
+msgid "Teams"
+msgstr "Equipos"
 
 #. module: rma
 #: model:ir.model.fields,help:rma.field_res_users__rma_team_id

--- a/rma/i18n/fr.po
+++ b/rma/i18n/fr.po
@@ -713,8 +713,8 @@ msgstr "Créer une nouvelle finalisation RMA"
 
 #. module: rma
 #: model_terms:ir.actions.act_window,help:rma.action_rma_tag
-msgid "Create a new RMA tag"
-msgstr "Créer une nouvelle étiquette RMA"
+msgid "Create a new tag"
+msgstr "Créer une nouvelle étiquette"
 
 #. module: rma
 #: model:ir.model.fields,field_description:rma.field_rma__create_uid
@@ -1215,9 +1215,9 @@ msgstr ""
 #. module: rma
 #: model_terms:ir.actions.act_window,help:rma.action_rma_tag
 msgid ""
-"Manage RMA tags to better classify them for tracking and analysis purposes."
+"Manage tags to better classify them for tracking and analysis purposes."
 msgstr ""
-"Gérez les étiquettes RMA pour mieux les classer à des fins de suivi et "
+"Gérez les étiquettes pour mieux les classer à des fins de suivi et "
 "d'analyse."
 
 #. module: rma
@@ -1746,8 +1746,8 @@ msgstr "Retour RMA"
 #. module: rma
 #: model:ir.actions.act_window,name:rma.rma_team_action
 #: model:ir.model.fields,field_description:rma.field_rma__team_id
-msgid "RMA team"
-msgstr "Équipe RMA"
+msgid "Teams"
+msgstr "Équipes"
 
 #. module: rma
 #: model:ir.model.fields,field_description:rma.field_res_partner__rma_ids

--- a/rma/i18n/it.po
+++ b/rma/i18n/it.po
@@ -805,8 +805,8 @@ msgstr "Crea una nuova chiusura RMA"
 
 #. module: rma
 #: model_terms:ir.actions.act_window,help:rma.action_rma_tag
-msgid "Create a new RMA tag"
-msgstr "Crea una nuova etichetta RMA"
+msgid "Create a new tag"
+msgstr "Crea una nuova etichetta"
 
 #. module: rma
 #: model:ir.model.fields,field_description:rma.field_rma__create_uid
@@ -1317,9 +1317,9 @@ msgstr ""
 #. module: rma
 #: model_terms:ir.actions.act_window,help:rma.action_rma_tag
 msgid ""
-"Manage RMA tags to better classify them for tracking and analysis purposes."
+"Manage tags to better classify them for tracking and analysis purposes."
 msgstr ""
-"Gestisci i tag RMA per classificarli meglio ai fini del monitoraggio e "
+"Gestisci i tag per classificarli meglio ai fini del monitoraggio e "
 "dell'analisi."
 
 #. module: rma
@@ -1791,8 +1791,8 @@ msgstr "Etichette RMA"
 #: model:ir.model.fields,field_description:rma.field_res_users__rma_team_id
 #: model:ir.ui.menu,name:rma.rma_configuration_rma_team_menu
 #: model_terms:ir.ui.view,arch_db:rma.rma_team_view_form
-msgid "RMA Team"
-msgstr "Team RMA"
+msgid "Teams"
+msgstr "Teams"
 
 #. module: rma
 #: model:ir.model.fields,help:rma.field_res_users__rma_team_id

--- a/rma/i18n/nl.po
+++ b/rma/i18n/nl.po
@@ -1700,7 +1700,7 @@ msgstr ""
 #. module: rma
 #: model:ir.actions.act_window,name:rma.rma_team_action
 #: model:ir.model.fields,field_description:rma.field_rma__team_id
-msgid "RMA team"
+msgid "Teams"
 msgstr ""
 
 #. module: rma

--- a/rma/i18n/pt.po
+++ b/rma/i18n/pt.po
@@ -1725,8 +1725,8 @@ msgstr "Devolução RMA"
 #. module: rma
 #: model:ir.actions.act_window,name:rma.rma_team_action
 #: model:ir.model.fields,field_description:rma.field_rma__team_id
-msgid "RMA team"
-msgstr "Equipa RMA"
+msgid "Teams"
+msgstr "Equipas"
 
 #. module: rma
 #: model:ir.model.fields,field_description:rma.field_res_partner__rma_ids

--- a/rma/i18n/pt_BR.po
+++ b/rma/i18n/pt_BR.po
@@ -1657,8 +1657,8 @@ msgstr ""
 #: model:ir.model.fields,field_description:rma.field_res_users__rma_team_id
 #: model:ir.ui.menu,name:rma.rma_configuration_rma_team_menu
 #: model_terms:ir.ui.view,arch_db:rma.rma_team_view_form
-msgid "RMA Team"
-msgstr "Equipe RMA"
+msgid "Teams"
+msgstr "Equipes"
 
 #. module: rma
 #: model:ir.model.fields,help:rma.field_res_users__rma_team_id

--- a/rma/i18n/rma.pot
+++ b/rma/i18n/rma.pot
@@ -1625,7 +1625,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:rma.field_res_users__rma_team_id
 #: model:ir.ui.menu,name:rma.rma_configuration_rma_team_menu
 #: model_terms:ir.ui.view,arch_db:rma.rma_team_view_form
-msgid "RMA Team"
+msgid "Teams"
 msgstr ""
 
 #. module: rma

--- a/rma/i18n/ro.po
+++ b/rma/i18n/ro.po
@@ -1719,8 +1719,8 @@ msgstr ""
 #. module: rma
 #: model:ir.actions.act_window,name:rma.rma_team_action
 #: model:ir.model.fields,field_description:rma.field_rma__team_id
-msgid "RMA team"
-msgstr "Echipă"
+msgid "Teams"
+msgstr "Echipe"
 
 #. module: rma
 #: model:ir.model.fields,field_description:rma.field_res_partner__rma_ids

--- a/rma/i18n/zh_CN.po
+++ b/rma/i18n/zh_CN.po
@@ -1702,7 +1702,7 @@ msgstr ""
 #. module: rma
 #: model:ir.actions.act_window,name:rma.rma_team_action
 #: model:ir.model.fields,field_description:rma.field_rma__team_id
-msgid "RMA team"
+msgid "Teams"
 msgstr ""
 
 #. module: rma

--- a/rma/views/rma_tag_views.xml
+++ b/rma/views/rma_tag_views.xml
@@ -19,7 +19,7 @@
         </field>
     </record>
     <record id="view_rma_tag_form" model="ir.ui.view">
-        <field name="name">Rma Tags</field>
+        <field name="name">Tags</field>
         <field name="model">rma.tag</field>
         <field name="arch" type="xml">
             <form string="RMA Tag">
@@ -33,7 +33,7 @@
         </field>
     </record>
     <record id="view_rma_tag_list" model="ir.ui.view">
-        <field name="name">RMA Tags</field>
+        <field name="name">Tags</field>
         <field name="model">rma.tag</field>
         <field eval="6" name="priority" />
         <field name="arch" type="xml">
@@ -45,21 +45,21 @@
         </field>
     </record>
     <record id="action_rma_tag" model="ir.actions.act_window">
-        <field name="name">RMA Tags</field>
+        <field name="name">Tags</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">rma.tag</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
-            Create a new RMA tag
+            Create a new tag
             </p>
             <p>
-            Manage RMA tags to better classify them for tracking and analysis purposes.
+            Manage tags to better classify them for tracking and analysis purposes.
             </p>
         </field>
     </record>
     <menuitem
         id="rma_configuration_rma_tag_menu"
-        name="RMA Tags"
+        name="Tags"
         parent="rma_configuration_menu"
         action="action_rma_tag"
     />

--- a/rma/views/rma_team_views.xml
+++ b/rma/views/rma_team_views.xml
@@ -122,18 +122,18 @@
         </field>
     </record>
     <record id="rma_team_action" model="ir.actions.act_window">
-        <field name="name">RMA team</field>
+        <field name="name">Teams</field>
         <field name="res_model">rma.team</field>
         <field name="view_mode">list,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
-                Click to add a new RMA.
+                Click to add a new team.
             </p>
         </field>
     </record>
     <menuitem
         id="rma_configuration_rma_team_menu"
-        name="RMA Team"
+        name="Teams"
         parent="rma_configuration_menu"
         action="rma_team_action"
     />

--- a/rma_reason/i18n/es.po
+++ b/rma_reason/i18n/es.po
@@ -160,8 +160,8 @@ msgstr "Motivo de RMA"
 #. module: rma_reason
 #: model:ir.actions.act_window,name:rma_reason.rma_reason_act_window
 #: model:ir.ui.menu,name:rma_reason.rma_reason_menu
-msgid "RMA Reasons"
-msgstr "Motivos de RMA"
+msgid "Reasons"
+msgstr "Motivos"
 
 #. module: rma_reason
 #: model:ir.model.fields,field_description:rma_reason.field_rma__reason_id

--- a/rma_reason/i18n/it.po
+++ b/rma_reason/i18n/it.po
@@ -168,8 +168,8 @@ msgstr "Motivo RMA"
 #. module: rma_reason
 #: model:ir.actions.act_window,name:rma_reason.rma_reason_act_window
 #: model:ir.ui.menu,name:rma_reason.rma_reason_menu
-msgid "RMA Reasons"
-msgstr "Motivi RMA"
+msgid "Reasons"
+msgstr "Motivi"
 
 #. module: rma_reason
 #: model:ir.model.fields,field_description:rma_reason.field_rma__reason_id

--- a/rma_reason/i18n/rma_reason.pot
+++ b/rma_reason/i18n/rma_reason.pot
@@ -145,7 +145,7 @@ msgstr ""
 #. module: rma_reason
 #: model:ir.actions.act_window,name:rma_reason.rma_reason_act_window
 #: model:ir.ui.menu,name:rma_reason.rma_reason_menu
-msgid "RMA Reasons"
+msgid "Reasons"
 msgstr ""
 
 #. module: rma_reason

--- a/rma_reason/views/rma_reason.xml
+++ b/rma_reason/views/rma_reason.xml
@@ -41,7 +41,7 @@
     </record>
 
     <record model="ir.actions.act_window" id="rma_reason_act_window">
-        <field name="name">RMA Reasons</field>
+        <field name="name">Reasons</field>
         <field name="res_model">rma.reason</field>
         <field name="view_mode">list,form</field>
         <field name="domain">[]</field>
@@ -49,7 +49,7 @@
     </record>
 
     <record model="ir.ui.menu" id="rma_reason_menu">
-        <field name="name">RMA Reasons</field>
+        <field name="name">Reasons</field>
         <field name="parent_id" ref="rma.rma_configuration_menu" />
         <field name="action" ref="rma_reason_act_window" />
         <field name="sequence" eval="16" />


### PR DESCRIPTION
Remove the RMA text from some menus as it is redundant

If we are in the RMA > Settings > Teams menu, there is no need for that menu to be RMA Teams

Please @carlos-lopez-tecnativa and @pedrobaeza can you review it?

@Tecnativa