### PR TITLE
[18.0][IMP] rma: Add the appropriate depends to the compute methods + Possibility of return or replace if it has already been received and the operation is set to Manually on Confirm

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -394,7 +394,7 @@ class Rma(models.Model):
         for r in self:
             r.remaining_qty = r.product_uom_qty - r.delivered_qty
 
-    @api.depends("state")
+    @api.depends("state", "operation_id", "operation_id.action_create_refund")
     def _compute_can_be_refunded(self):
         """Compute 'can_be_refunded'. This field controls the visibility
         of 'Refund' button in the rma form view and determinates if
@@ -411,7 +411,9 @@ class Rma(models.Model):
                 and record.state == "confirmed"
             )
 
-    @api.depends("remaining_qty", "state", "operation_id.action_create_delivery")
+    @api.depends(
+        "remaining_qty", "state", "operation_id", "operation_id.action_create_delivery"
+    )
     def _compute_can_be_returned(self):
         """Compute 'can_be_returned'. This field controls the visibility
         of the 'Return to customer' button in the rma form
@@ -434,7 +436,7 @@ class Rma(models.Model):
                 )
             )
 
-    @api.depends("state")
+    @api.depends("state", "operation_id", "operation_id.action_create_delivery")
     def _compute_can_be_replaced(self):
         """Compute 'can_be_replaced'. This field controls the visibility
         of 'Replace' button in the rma form

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -432,7 +432,7 @@ class Rma(models.Model):
                 or (
                     r.operation_id.action_create_delivery
                     in ("manual_on_confirm", "automatic_on_confirm")
-                    and r.state == "confirmed"
+                    and r.state in ("confirmed", "received")
                 )
             )
 
@@ -458,7 +458,7 @@ class Rma(models.Model):
             ) or (
                 r.operation_id.action_create_delivery
                 in ("manual_on_confirm", "automatic_on_confirm")
-                and r.state == "confirmed"
+                and r.state in ("confirmed", "received")
             )
 
     @api.depends("state", "remaining_qty", "manual_finish_allowed")


### PR DESCRIPTION
Add the appropriate depends to the compute methods.

Possibility of return or replace if it has already been received and the operation is set to Manually on Confirm.

Steps to reproduce:
- Modify an operation and set Delivery Action=Manually on Confirm
- Create an RMA and generate reception picking
- Validate the reception picking
- The RMA does not have the Return to customer or Replace button

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT60352
