### PR TITLE
[18.0][IMP] rma: Possibility of refund if it has already been received and the operation is set to Manually on Confirm

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -408,7 +408,7 @@ class Rma(models.Model):
             ) or (
                 record.operation_id.action_create_refund
                 in ("manual_on_confirm", "automatic_on_confirm")
-                and record.state == "confirmed"
+                and record.state in ("confirmed", "received")
             )
 
     @api.depends(


### PR DESCRIPTION
Possibility of refund if it has already been received and the operation is set to Manually on Confirm

Steps to reproduce:
- Modify an operation and set Refund Action=Manually on Confirm
- Create an RMA and generate reception picking
- Validate the reception picking
- The RMA does not have the Refund button

Similar to https://github.com/OCA/rma/commit/fb1bb64ee17830c715f3ac0cec71cd6ea02b6d00

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT60705