### PR TITLE
[18.0][FIX] rma + rma_sale: Remove unnecessary invisible field

### DIFF
--- a/rma/wizard/stock_picking_return_views.xml
+++ b/rma/wizard/stock_picking_return_views.xml
@@ -20,7 +20,6 @@
                     invisible="not different_return_product"
                     required="different_return_product and quantity>0"
                 />
-                <field name="different_return_product" invisible="1" />
             </xpath>
             <field name="product_return_moves" position="before">
                 <group name="group_rma">

--- a/rma_sale/wizard/sale_order_rma_wizard_views.xml
+++ b/rma_sale/wizard/sale_order_rma_wizard_views.xml
@@ -35,7 +35,6 @@
                                 invisible="not different_return_product"
                                 required="different_return_product and quantity>0"
                             />
-                            <field name="different_return_product" invisible="1" />
                         </list>
                     </field>
                 </group>


### PR DESCRIPTION
Remove unnecessary invisible field

Also, if it exists in the view, it should have `column_invisible` defined.

Please @pedrobaeza can you review it?

@Tecnativa