### PR TITLE
[18.0][IMP] rma_batch: Propagate location change from batch to RMAs

### DIFF
--- a/rma_batch/models/rma.py
+++ b/rma_batch/models/rma.py
@@ -62,13 +62,15 @@ class Rma(models.Model):
                 rec.team_id = rec.batch_id.team_id
         return res
 
-    @api.depends("picking_id", "product_id", "company_id", "batch_id")
+    @api.depends("picking_id", "product_id", "company_id", "batch_id.location_id")
     def _compute_location_id(self):
         """Override to consider RMA Batch location"""
         super()._compute_location_id()
         # Apply RMA Batch location if set
         for record in self:
-            if record.batch_id and record.batch_id.location_id:
+            if record.state != "draft":
+                continue
+            if record.batch_id.location_id:
                 record.location_id = record.batch_id.location_id
 
         return

--- a/rma_batch/models/rma_batch.py
+++ b/rma_batch/models/rma_batch.py
@@ -9,6 +9,7 @@ class RmaBatch(models.Model):
     _name = "rma.batch"
     _description = "RMA Batch"
     _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "date desc, id desc"
 
     name = fields.Char(
         string="Reference",

--- a/rma_batch/tests/test_rma_batch.py
+++ b/rma_batch/tests/test_rma_batch.py
@@ -113,6 +113,19 @@ class TestRmaBatch(TransactionCase):
         self.assertEqual(rma.team_id, self.team)
         self.assertEqual(rma.tag_ids, self.tag1)
 
+    def test_change_location_on_batch_propagates_to_rmas(self):
+        """check that changing the location on a draft batch updates
+        the location on the associated RMAs"""
+        warehouse = self.env["stock.warehouse"].search(
+            [("company_id", "=", self.env.company.id)], limit=1
+        )
+        rma_location = warehouse.rma_loc_id
+        batch = self._create_batch([(self.product, 5), (self.product2, 3)])
+        self.assertEqual(batch.state, "draft")
+        batch.location_id = rma_location
+        for rma in batch.rma_ids:
+            self.assertEqual(rma.location_id, rma_location)
+
     def test_unlink_forbidden_when_non_draft_rma(self):
         """ensure that a batch can't be deleted if it contains any RMA
         not in draft state"""


### PR DESCRIPTION
The _compute_location_id dependency was on "batch_id" instead of
  "batch_id.location_id", so changing the location on a draft batch
  did not trigger recomputation on the associated RMAs.