### PR TITLE
[18.0][IMP] rma: Define the expected configuration (action_create_* fields) in operations

### DIFF
--- a/rma/data/rma_operation_data.xml
+++ b/rma/data/rma_operation_data.xml
@@ -2,11 +2,14 @@
 <data noupdate="1">
     <record id="rma_operation_replace" model="rma.operation">
         <field name="name">Replace</field>
+        <field name="action_create_refund" />
     </record>
     <record id="rma_operation_return" model="rma.operation">
         <field name="name">Repair</field>
+        <field name="action_create_refund" />
     </record>
     <record id="rma_operation_refund" model="rma.operation">
         <field name="name">Refund</field>
+        <field name="action_create_delivery" />
     </record>
 </data>

--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -169,6 +169,7 @@ class Rma(models.Model):
     operation_id = fields.Many2one(
         comodel_name="rma.operation",
         string="Requested operation",
+        tracking=True,
     )
     state = fields.Selection(
         [

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -74,9 +74,34 @@ class TestRma(BaseCommon):
         )
         cls.env.ref("rma.group_rma_manual_finalization").users |= cls.env.user
         cls.warehouse = cls.env.ref("stock.warehouse0")
+        # Operation data
+        cls.operation_replace = cls.env["rma.operation"].create(
+            {
+                "name": "Test replace",
+                "action_create_receipt": "automatic_on_confirm",
+                "action_create_delivery": "manual_after_receipt",
+                "action_create_refund": False,
+            }
+        )
+        cls.operation_return = cls.env["rma.operation"].create(
+            {
+                "name": "Test return",
+                "action_create_receipt": "automatic_on_confirm",
+                "action_create_delivery": "manual_after_receipt",
+                "action_create_refund": False,
+            }
+        )
+        cls.operation_refund = cls.env["rma.operation"].create(
+            {
+                "name": "Test refund",
+                "action_create_receipt": "automatic_on_confirm",
+                "action_create_delivery": False,
+                "action_create_refund": "manual_after_receipt",
+            }
+        )
         # Ensure grouping
         cls.env.company.rma_return_grouping = True
-        cls.operation = cls.env.ref("rma.rma_operation_replace")
+        cls.operation = cls.operation_replace
         cls.operation_no_group = cls.operation.copy(
             {
                 "name": f"{cls.operation.name} (no group)",
@@ -84,8 +109,9 @@ class TestRma(BaseCommon):
             }
         )
 
+    @classmethod
     def _create_rma(
-        self, partner=None, product=None, qty=None, location=None, operation=None
+        cls, partner=None, product=None, qty=None, location=None, operation=None
     ):
         vals = {}
         if partner:
@@ -99,9 +125,9 @@ class TestRma(BaseCommon):
         if operation:
             vals["operation_id"] = operation.id
         elif operation is None:
-            vals["operation_id"] = self.operation.id
-        vals["user_id"] = self.env.user.id
-        return self.env["rma"].create(vals)
+            vals["operation_id"] = cls.operation.id
+        vals["user_id"] = cls.env.user.id
+        return cls.env["rma"].create(vals)
 
     def _create_confirm_receive(
         self, partner=None, product=None, qty=None, location=None, operation=None
@@ -367,11 +393,13 @@ class TestRmaCase(TestRma):
     @users("__system__", "user_rma")
     @mute_logger("odoo.models.unlink")
     def test_action_refund(self):
-        rma = self._create_confirm_receive(self.partner, self.product, 10, self.rma_loc)
+        rma = self._create_confirm_receive(
+            self.partner, self.product, 10, self.rma_loc, self.operation_refund
+        )
         self.assertEqual(rma.state, "received")
         self.assertTrue(rma.can_be_refunded)
-        self.assertTrue(rma.can_be_returned)
-        self.assertTrue(rma.can_be_replaced)
+        self.assertFalse(rma.can_be_returned)
+        self.assertFalse(rma.can_be_replaced)
         rma.action_refund()
         self.assertEqual(rma.refund_id.move_type, "out_refund")
         self.assertEqual(rma.refund_id.state, "draft")
@@ -404,18 +432,20 @@ class TestRmaCase(TestRma):
     def test_mass_refund(self):
         # Create, confirm and receive rma_1
         rma_1 = self._create_confirm_receive(
-            self.partner, self.product, 10, self.rma_loc
+            self.partner, self.product, 10, self.rma_loc, self.operation_refund
         )
         # create, confirm and receive 3 more RMAs
         # rma_2: Same partner and same product as rma_1
         rma_2 = self._create_confirm_receive(
-            self.partner, self.product, 15, self.rma_loc
+            self.partner, self.product, 15, self.rma_loc, self.operation_refund
         )
         # rma_3: Same partner and different product than rma_1
         product = self.product_product.create(
             {"name": "Product 2 test", "type": "consu", "is_storable": True}
         )
-        rma_3 = self._create_confirm_receive(self.partner, product, 20, self.rma_loc)
+        rma_3 = self._create_confirm_receive(
+            self.partner, product, 20, self.rma_loc, self.operation_refund
+        )
         # rma_4: Different partner and same product as rma_1
         partner = self.res_partner.create(
             {
@@ -424,7 +454,9 @@ class TestRmaCase(TestRma):
                 "company_id": self.company.id,
             }
         )
-        rma_4 = self._create_confirm_receive(partner, product, 25, self.rma_loc)
+        rma_4 = self._create_confirm_receive(
+            partner, product, 25, self.rma_loc, self.operation_refund
+        )
         # all rmas are ready to refund
         all_rmas = rma_1 | rma_2 | rma_3 | rma_4
         self.assertEqual(all_rmas.mapped("state"), ["received"] * 4)
@@ -814,7 +846,7 @@ class TestRmaCase(TestRma):
         self.assertEqual(new_rma.delivered_qty, 0)
         self.assertEqual(new_rma.remaining_qty, 6)
         self.assertEqual(new_rma.state, "received")
-        self.assertTrue(new_rma.can_be_refunded)
+        self.assertFalse(new_rma.can_be_refunded)
         self.assertTrue(new_rma.can_be_returned)
         self.assertTrue(new_rma.can_be_replaced)
         self.assertEqual(new_rma.move_id, rma.move_id)
@@ -825,15 +857,17 @@ class TestRmaCase(TestRma):
 
     @mute_logger("odoo.models.unlink")
     def test_rma_to_receive_on_delete_invoice(self):
-        rma = self._create_confirm_receive(self.partner, self.product, 10, self.rma_loc)
+        rma = self._create_confirm_receive(
+            self.partner, self.product, 10, self.rma_loc, self.operation_refund
+        )
         rma.action_refund()
         self.assertEqual(rma.state, "refunded")
         rma.refund_id.unlink()
         self.assertFalse(rma.refund_id)
         self.assertEqual(rma.state, "received")
         self.assertTrue(rma.can_be_refunded)
-        self.assertTrue(rma.can_be_returned)
-        self.assertTrue(rma.can_be_replaced)
+        self.assertFalse(rma.can_be_returned)
+        self.assertFalse(rma.can_be_replaced)
 
     def test_rma_picking_type_default_values(self):
         warehouse = self.env["stock.warehouse"].create(

--- a/rma/tests/test_rma_dashboard.py
+++ b/rma/tests/test_rma_dashboard.py
@@ -9,14 +9,19 @@ AWAITING_ACTION_STATES = ["waiting_return", "waiting_replacement", "confirmed"]
 
 class TestRmaDashboard(TestRma):
     def test_0(self):
-        operation_replace = self.env.ref("rma.rma_operation_replace")
-        operation_return = self.env.ref("rma.rma_operation_return")
-        operation_refund = self.env.ref("rma.rma_operation_refund")
         replace_draft_1 = self._create_rma(
-            self.partner, self.product, 1, self.rma_loc, operation=operation_replace
+            self.partner,
+            self.product,
+            1,
+            self.rma_loc,
+            operation=self.operation_replace,
         )
         self._create_rma(
-            self.partner, self.product, 1, self.rma_loc, operation=operation_replace
+            self.partner,
+            self.product,
+            1,
+            self.rma_loc,
+            operation=self.operation_replace,
         )  # replace_draft_2
         replace_draft_1.copy({"state": "confirmed"})  # replace_confirmed
         replace_draft_1.copy({"state": "received"})  # replace_received
@@ -25,48 +30,52 @@ class TestRmaDashboard(TestRma):
             {"state": "waiting_replacement"}
         )
         return_draft = self._create_rma(
-            self.partner, self.product, 1, self.rma_loc, operation=operation_return
+            self.partner, self.product, 1, self.rma_loc, operation=self.operation_return
         )
         return_draft.copy({"state": "confirmed"})  # return_confirmed
         return_draft.copy({"state": "waiting_return"})  # return_waiting_return
         return_draft.copy({"state": "returned"})  # return_returned
         return_draft.copy({"state": "finished"})  # return_finished
         refund_draft = self._create_rma(
-            self.partner, self.product, 1, self.rma_loc, operation=operation_refund
+            self.partner, self.product, 1, self.rma_loc, operation=self.operation_refund
         )
         refund_draft.copy({"state": "finished"})  # refund_refunded
 
-        self.assertEqual(operation_replace.count_rma_draft, 2)
-        self.assertEqual(operation_replace.count_rma_awaiting_action, 3)
-        self.assertEqual(operation_replace.count_rma_processed, 1)
+        self.assertEqual(self.operation_replace.count_rma_draft, 2)
+        self.assertEqual(self.operation_replace.count_rma_awaiting_action, 3)
+        self.assertEqual(self.operation_replace.count_rma_processed, 1)
 
-        self.assertEqual(operation_return.count_rma_draft, 1)
-        self.assertEqual(operation_return.count_rma_awaiting_action, 2)
-        self.assertEqual(operation_return.count_rma_processed, 1)
+        self.assertEqual(self.operation_return.count_rma_draft, 1)
+        self.assertEqual(self.operation_return.count_rma_awaiting_action, 2)
+        self.assertEqual(self.operation_return.count_rma_processed, 1)
 
-        self.assertEqual(operation_refund.count_rma_draft, 1)
-        self.assertEqual(operation_refund.count_rma_awaiting_action, 0)
-        self.assertEqual(operation_refund.count_rma_processed, 1)
+        self.assertEqual(self.operation_refund.count_rma_draft, 1)
+        self.assertEqual(self.operation_refund.count_rma_awaiting_action, 0)
+        self.assertEqual(self.operation_refund.count_rma_processed, 1)
 
-        action = operation_replace.get_action_rma_tree_draft()
-        self.assertListEqual(
-            ["&", ("operation_id", "=", operation_replace.id), ("state", "=", "draft")],
-            action.get("domain"),
-        )
-        action = operation_replace.get_action_rma_tree_awaiting_action()
+        action = self.operation_replace.get_action_rma_tree_draft()
         self.assertListEqual(
             [
                 "&",
-                ("operation_id", "=", operation_replace.id),
+                ("operation_id", "=", self.operation_replace.id),
+                ("state", "=", "draft"),
+            ],
+            action.get("domain"),
+        )
+        action = self.operation_replace.get_action_rma_tree_awaiting_action()
+        self.assertListEqual(
+            [
+                "&",
+                ("operation_id", "=", self.operation_replace.id),
                 ("state", "in", AWAITING_ACTION_STATES),
             ],
             action.get("domain"),
         )
-        action = operation_replace.get_action_rma_tree_processed()
+        action = self.operation_replace.get_action_rma_tree_processed()
         self.assertListEqual(
             [
                 "&",
-                ("operation_id", "=", operation_replace.id),
+                ("operation_id", "=", self.operation_replace.id),
                 ("state", "in", PROCESSED_STATES),
             ],
             action.get("domain"),

--- a/rma/views/rma_views.xml
+++ b/rma/views/rma_views.xml
@@ -352,7 +352,10 @@
                                 name="origin"
                                 readonly="state in ['locked', 'cancelled']"
                             />
-                            <field name="operation_id" />
+                            <field
+                                name="operation_id"
+                                readonly="state in ['refunded', 'returned', 'replaced', 'finished', 'locked', 'cancelled']"
+                            />
                             <field
                                 name="finalization_id"
                                 readonly="1"

--- a/rma_repair/tests/test_rma_repair_order.py
+++ b/rma_repair/tests/test_rma_repair_order.py
@@ -3,29 +3,17 @@
 
 from odoo.tests import Form
 
-from odoo.addons.base.tests.common import BaseCommon
+from odoo.addons.rma.tests.test_rma import TestRma
 
 
-class RMARepairOrderTest(BaseCommon):
+class RMARepairOrderTest(TestRma):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.warehouse_company = cls.env["stock.warehouse"].search(
-            [("company_id", "=", cls.env.company.id)], limit=1
-        )
-        cls.rma_loc = cls.warehouse_company.rma_loc_id
-        cls.res_partner = cls.env["res.partner"].create({"name": "Test"})
-        cls.operation = cls.env.ref("rma.rma_operation_return")
-        cls.operation.action_create_repair = False
-        cls.action_create_repair = "manual_after_receipt"
-        cls.rma = cls.env["rma"].create(
-            {
-                "product_id": cls.env.ref("product.product_delivery_01").id,
-                "product_uom_qty": 2,
-                "location_id": cls.rma_loc.id,
-                "partner_id": cls.res_partner.id,
-                "operation_id": cls.operation.id,
-            }
+        cls.operation_return.action_create_repair = "automatic_on_confirm"
+        cls.operation = cls.operation_return
+        cls.rma = cls._create_rma(
+            cls.partner, cls.product, 2, cls.rma_loc, cls.operation_return
         )
         repair_form = Form(
             cls.env["repair.order"].with_context(
@@ -35,14 +23,8 @@ class RMARepairOrderTest(BaseCommon):
             )
         )
         cls.repair_order = repair_form.save()
-        cls.rma_without_repair = cls.env["rma"].create(
-            {
-                "product_id": cls.env.ref("product.product_delivery_01").id,
-                "product_uom_qty": 2,
-                "location_id": cls.rma_loc.id,
-                "partner_id": cls.res_partner.id,
-                "operation_id": cls.operation.id,
-            }
+        cls.rma_without_repair = cls._create_rma(
+            cls.partner, cls.product, 2, cls.rma_loc, cls.operation_return
         )
 
     @classmethod
@@ -88,7 +70,7 @@ class RMARepairOrderTest(BaseCommon):
         self.repair_order.action_repair_cancel()
         self.assertFalse(self.rma.can_be_returned)
         self.assertTrue(self.rma.can_be_replaced)
-        self.assertTrue(self.rma.can_be_refunded)
+        self.assertFalse(self.rma.can_be_refunded)
 
     def test_action_view_rma_repair_order(self):
         self.assertEqual(
@@ -122,6 +104,7 @@ class RMARepairOrderTest(BaseCommon):
         - verify repair is created and no longer allowed afterward
         """
 
+        self.operation.action_create_repair = False
         self.assertFalse(self.operation.action_create_repair)
         self.rma_without_repair.action_confirm()
         self.assertFalse(self.rma_without_repair.can_be_repaired)

--- a/rma_repair_lot/tests/test_rma_repair_lot.py
+++ b/rma_repair_lot/tests/test_rma_repair_lot.py
@@ -1,37 +1,20 @@
 # Copyright 2024 Antoni Marroig(APSL-Nagarro)<amarroig@apsl.net>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.addons.base.tests.common import BaseCommon
+from odoo.addons.rma.tests.test_rma import TestRma
 
 
-class RMARepairOrderTest(BaseCommon):
+class RMARepairOrderTest(TestRma):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.warehouse_company = cls.env["stock.warehouse"].search(
-            [("company_id", "=", cls.env.company.id)], limit=1
+        cls.product.tracking = "lot"
+        cls.operation = cls.operation_return
+        cls.rma = cls._create_rma(
+            cls.partner, cls.product, 2, cls.rma_loc, cls.operation_return
         )
-        cls.product = cls.env["product.product"].create(
-            {
-                "name": "Test product",
-                "is_storable": True,
-                "tracking": "lot",
-            }
-        )
-        cls.rma_loc = cls.warehouse_company.rma_loc_id
-        cls.res_partner = cls.env["res.partner"].create({"name": "Test"})
-        cls.operation = cls.env.ref("rma.rma_operation_return")
         cls.lot = cls.env["stock.lot"].create({"product_id": cls.product.id})
-        cls.rma = cls.env["rma"].create(
-            {
-                "product_id": cls.product.id,
-                "product_uom_qty": 2,
-                "location_id": cls.rma_loc.id,
-                "partner_id": cls.res_partner.id,
-                "operation_id": cls.operation.id,
-                "lot_id": cls.lot.id,
-            }
-        )
+        cls.rma.lot_id = cls.lot
 
     def test_repair_order_default_vals(self):
         vals = self.rma._get_repair_order_default_vals()

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -9,29 +9,22 @@ from odoo.tests import Form, new_test_user
 from odoo.tests.common import users
 from odoo.tools import mute_logger
 
-from odoo.addons.base.tests.common import BaseCommon
+from odoo.addons.rma.tests.test_rma import TestRma
 
 
-class TestRmaSaleBase(BaseCommon):
+class TestRmaSaleBase(TestRma):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.res_partner = cls.env["res.partner"]
-        cls.product_product = cls.env["product.product"]
         cls.so_model = cls.env["sale.order"]
-
         cls.product_1 = cls.product_product.create(
             {"name": "Product test 1", "type": "consu", "is_storable": True}
         )
         cls.product_2 = cls.product_product.create(
             {"name": "Product test 2", "type": "consu", "is_storable": True}
         )
-        cls.partner = cls.res_partner.create(
-            {"name": "Partner test", "email": "partner@rma"}
-        )
+        cls.partner.email = "partner@rma"
         cls.report_model = cls.env["ir.actions.report"]
-        cls.rma_operation_model = cls.env["rma.operation"]
-        cls.operation = cls.env.ref("rma.rma_operation_replace")
         cls._partner_portal_wizard(cls.partner)
         cls.wh = cls.env.ref("stock.warehouse0")
         cls.env["stock.quant"]._update_available_quantity(
@@ -138,6 +131,7 @@ class TestRmaSale(TestRmaSaleBase):
 
     @mute_logger("odoo.models.unlink")
     def test_create_rma_from_so(self):
+        self.operation.action_create_refund = "manual_after_receipt"
         order = self.sale_order
         wizard = self._rma_sale_wizard(order)
         rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
@@ -184,7 +178,6 @@ class TestRmaSale(TestRmaSaleBase):
         wizard_obj = (
             self.env["sale.order.rma.wizard"].sudo().with_context(active_id=order.id)
         )
-        operation = self.rma_operation_model.sudo().search([], limit=1)
         line_vals = [
             Command.create(
                 {
@@ -194,7 +187,7 @@ class TestRmaSale(TestRmaSaleBase):
                     "allowed_quantity": order.order_line.qty_delivered,
                     "uom_id": order.order_line.product_uom.id,
                     "picking_id": order.picking_ids[0].id,
-                    "operation_id": operation.id,
+                    "operation_id": self.operation.id,
                 },
             )
         ]
@@ -245,12 +238,11 @@ class TestRmaSale(TestRmaSaleBase):
     def test_report_rma(self):
         wizard = self._rma_sale_wizard(self.sale_order)
         rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
-        operation = self.rma_operation_model.sudo().search([], limit=1)
-        rma.operation_id = operation.id
+        rma.operation_id = self.operation_replace
         res = self.env["ir.actions.report"]._render_qweb_html("rma.report_rma", rma.ids)
         res = str(res[0])
         self.assertRegex(res, self.sale_order.name)
-        self.assertRegex(res, operation.name)
+        self.assertRegex(res, self.operation_replace.name)
 
     def test_manual_refund_no_quantity_impact(self):
         """If the operation is meant for a manual refund, the delivered quantity

--- a/rma_sale_mrp/tests/test_rma_sale_mrp.py
+++ b/rma_sale_mrp/tests/test_rma_sale_mrp.py
@@ -69,6 +69,7 @@ class TestRmaSaleMrpBase(TestRmaSaleBase):
 
 class TestRmaSaleMrp(TestRmaSaleMrpBase):
     def test_create_rma_from_so(self):
+        self.operation.action_create_refund = "manual_after_receipt"
         order = self.sale_order
         out_pickings = self.order_out_picking + self.backorder
         wizard = self._rma_sale_wizard(order)

--- a/rma_sale_reason/tests/test_rma_sale_reason.py
+++ b/rma_sale_reason/tests/test_rma_sale_reason.py
@@ -14,7 +14,6 @@ class TestRmaSaleReason(TestRmaSaleBase):
     def setUpClass(cls):
         super().setUpClass()
         cls.rma_reason = cls.env.ref("rma_reason.rma_reason_defective_product")
-        cls.operation = cls.rma_operation_model.sudo().search([], limit=1)
         cls.sale_order = cls._create_sale_order([[cls.product_1, 5]])
         cls.sale_order.action_confirm()
         cls.order_line = cls.sale_order.order_line.filtered(


### PR DESCRIPTION
Define the expected configuration (action_create_* fields) in operations

Replace: Not refund
Repair: Not refund
Refund: Not delivery

Add tracking=True to operation_id field + Do not allow the operation_id field to be modified if it is already "completed"

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa
