### PR TITLE
[18.0][IMP] rma_sale: improve how to get allowed_quantity

### DIFF
--- a/rma_sale/controllers/sale_portal.py
+++ b/rma_sale/controllers/sale_portal.py
@@ -51,7 +51,7 @@ class CustomerPortal(CustomerPortal):
                 custom_vals.update({name: value})
         for vals in mapped_vals.values():
             sale_line = order_line_obj.browse(vals.get("sale_line_id")).sudo()
-            vals["allowed_quantity"] = sale_line.qty_delivered
+            vals["allowed_quantity"] = sale_line._get_rma_allowed_quantity(vals)
         # If no operation is filled, no RMA will be created
         line_vals = [
             Command.create(vals)

--- a/rma_sale/models/sale.py
+++ b/rma_sale/models/sale.py
@@ -181,3 +181,7 @@ class SaleOrderLine(models.Model):
                 }
             )
         return data
+
+    def _get_rma_allowed_quantity(self, vals=None):
+        self.ensure_one()
+        return self.qty_delivered


### PR DESCRIPTION
This change is made for `rma_sale_mrp`, because components are not in sale order. In that case we can override that method to get the correct quantity. I think that getting `allowed_quantity` from `qty_delivery` is right for products, but not for components.

Related: https://github.com/OCA/rma/pull/525
Anyways this should be backport, I have check in v16 and it is the same.

cc @Tecnativa 
ping @pedrobaeza @victoralmau 