### PR TITLE
[18.0][FIX] rma_sale_lot: Add domain to the lot_id field so that only the appropriate lots can be selected

### DIFF
--- a/rma_sale_lot/wizards/sale_order_rma_wizard.py
+++ b/rma_sale_lot/wizards/sale_order_rma_wizard.py
@@ -1,4 +1,5 @@
 # Copyright 2024 ACSONE SA/NV
+# Copyright 2026 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
@@ -18,8 +19,20 @@ class SaleOrderRmaWizard(models.TransientModel):
 class SaleOrderLineRmaWizard(models.TransientModel):
     _inherit = "sale.order.line.rma.wizard"
 
-    lot_id = fields.Many2one(comodel_name="stock.lot", string="Lot/Serial Number")
+    lot_id_domain = fields.Binary(compute="_compute_lot_id_domain")
+    lot_id = fields.Many2one(
+        comodel_name="stock.lot", string="Lot/Serial Number", domain="lot_id_domain"
+    )
     lots_visible = fields.Boolean(compute="_compute_lots_visible")
+
+    @api.depends("move_id", "product_id")
+    def _compute_lot_id_domain(self):
+        for rec in self:
+            smls = rec.move_id.move_line_ids.filtered(
+                lambda x: x.state == "done" and x.lot_id
+            )
+            domain = [("id", "in", smls.lot_id.ids)]
+            rec.lot_id_domain = domain
 
     @api.depends("product_id.tracking")
     def _compute_lots_visible(self):


### PR DESCRIPTION
Add domain to the `lot_id` field so that only the appropriate lots can be selected

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT61559