### PR TITLE
[FIX] rma_repair: auto delivery creation regardless of repair state

### DIFF
--- a/rma_repair/models/rma.py
+++ b/rma_repair/models/rma.py
@@ -35,7 +35,9 @@ class RMA(models.Model):
         res = super()._compute_can_be_returned()
         for r in self:
             r.can_be_returned = r.can_be_returned and (
-                not r.repair_id or r.repair_id.state == "done"
+                r.operation_id.action_create_delivery
+                in ("automatic_on_confirm", "automatic_after_receipt")
+                or (not r.repair_id or r.repair_id.state == "done")
             )
         return res
 
@@ -44,7 +46,9 @@ class RMA(models.Model):
         res = super()._compute_can_be_replaced()
         for r in self:
             r.can_be_replaced = r.can_be_replaced and (
-                not r.repair_id or r.repair_id.state == "cancel"
+                r.operation_id.action_create_delivery
+                in ("automatic_on_confirm", "automatic_after_receipt")
+                or (not r.repair_id or r.repair_id.state == "cancel")
             )
         return res
 

--- a/rma_repair/tests/test_rma_repair_order.py
+++ b/rma_repair/tests/test_rma_repair_order.py
@@ -195,3 +195,37 @@ class RMARepairOrderTest(TransactionCase):
         rma.action_confirm()
         self.assertTrue(rma.repair_id)
         self.assertFalse(rma.repair_id.user_id)
+
+    def test_automatically_create_return_and_repair_on_confirm(self):
+        """
+        Test automatic creation of return, repair, and delivery on confirmation
+
+        - receipt is automatically created on confirm
+        - repair is automatically created on confirm
+        - delivery is automatically created on confirm
+        """
+        self.operation.action_create_receipt = "automatic_on_confirm"
+        self.operation.action_create_repair = "automatic_on_confirm"
+        self.operation.action_create_delivery = "automatic_on_confirm"
+        self.rma_without_repair.action_confirm()
+        self.assertTrue(self.rma_without_repair.reception_move_id)
+        self.assertTrue(self.rma_without_repair.delivery_move_ids)
+        self.assertTrue(self.rma_without_repair.repair_id)
+
+    def test_automatically_create_return_and_repair_after_receipt(self):
+        """
+        Test automatic creation of repair and delivery after receipt
+
+        - receipt is automatically created on confirm
+        - repair and delivery are automatically created after receipt
+        """
+        self.operation.action_create_receipt = "automatic_on_confirm"
+        self.operation.action_create_repair = "automatic_after_receipt"
+        self.operation.action_create_delivery = "automatic_after_receipt"
+        self.rma_without_repair.action_confirm()
+        self.assertTrue(self.rma_without_repair.reception_move_id)
+        self.assertFalse(self.rma_without_repair.delivery_move_ids)
+        self.assertFalse(self.rma_without_repair.repair_id)
+        self._receive_rma(self.rma_without_repair)
+        self.assertTrue(self.rma_without_repair.delivery_move_ids)
+        self.assertTrue(self.rma_without_repair.repair_id)


### PR DESCRIPTION
When delivery is automatically created after RMA reception, it shouldn't be restricted by the repair state

The dependency between delivery and repair state is relevant for manual flows but shouldn't apply to automatic workflows