### PR TITLE
[18.0][FIX] rma_sale: Wrong method called in stock_picking_return

### DIFF
--- a/rma_sale/wizard/stock_picking_return.py
+++ b/rma_sale/wizard/stock_picking_return.py
@@ -17,13 +17,9 @@ class ReturnPicking(models.TransientModel):
             sale_order.partner_shipping_id,
         )
 
-    def _prepare_rma_values(self):
-        vals = super()._prepare_rma_values()
+    def _prepare_rma_vals(self):
+        vals = super()._prepare_rma_vals()
         sale_order = self.picking_id.sale_id
         if sale_order:
-            vals.update(
-                {
-                    "order_id": sale_order.id,
-                }
-            )
+            vals["order_id"] = sale_order.id
         return vals


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/rma/pull/562

Wrong method called in stock_picking_return

Please @pedrobaeza can you review it?

@Tecnativa