### PR TITLE
[18.0][FIX] rma_sale: Use the appropriate _is_outgoing() method in get_delivery_move()

### DIFF
--- a/rma_sale/models/sale.py
+++ b/rma_sale/models/sale.py
@@ -113,7 +113,7 @@ class SaleOrderLine(models.Model):
                 self == r.sale_line_id
                 and r.state == "done"
                 and not r.scrapped
-                and r.location_dest_id.usage == "customer"
+                and r._is_outgoing()
                 and (
                     not r.origin_returned_move_id
                     or (r.origin_returned_move_id and r.to_refund)

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -76,6 +76,19 @@ class TestRmaSale(TestRmaSaleBase):
         cls.order_out_picking.move_ids.quantity = 5
         cls.order_out_picking.button_validate()
 
+    def test_sale_order_line_get_delivery_move(self):
+        # Example of a use case: sale order with a partner from existing res.company
+        self.order_out_picking.move_ids.write(
+            {
+                "location_dest_id": self.env.ref(
+                    "stock.stock_location_inter_company"
+                ).id,
+            }
+        )
+        self.assertIn(
+            self.order_out_picking.move_ids, self.order_line.get_delivery_move()
+        )
+
     def test_rma_sale_computes_onchange(self):
         rma = self.env["rma"].new()
         # No m2m values when everything is selectable


### PR DESCRIPTION
Use the appropriate _is_outgoing() method in get_delivery_move()

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT61634