### PR TITLE
[18.0][FIX] rma_lot: Do not define move_orig_ids with other lot to avoid inconsistencies

### DIFF
--- a/rma_lot/models/rma.py
+++ b/rma_lot/models/rma.py
@@ -1,7 +1,7 @@
 # Copyright 2024 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import Command, api, fields, models
 
 
 class Rma(models.Model):
@@ -22,6 +22,13 @@ class Rma(models.Model):
     def _compute_lots_visible(self):
         for rec in self:
             rec.lots_visible = rec.product_id.tracking != "none"
+
+    def _prepare_delivery_procurement_vals(self, scheduled_date=None):
+        vals = super()._prepare_delivery_procurement_vals(scheduled_date=scheduled_date)
+        if vals.get("restrict_lot_id") and self.reception_move_id.restrict_lot_id:
+            if self.reception_move_id.restrict_lot_id.id != vals.get("restrict_lot_id"):
+                vals["move_orig_ids"] = [Command.clear()]  # Avoid inconsistencies
+        return vals
 
     def _prepare_reception_procurement_vals(self, group=None):
         vals = super()._prepare_reception_procurement_vals(group=group)

--- a/rma_lot/tests/test_rma_lot.py
+++ b/rma_lot/tests/test_rma_lot.py
@@ -1,8 +1,9 @@
 # Copyright 2020 Iryna Vyshnevska Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.tests import Form
+from odoo.tools import mute_logger
 
 from odoo.addons.base.tests.common import BaseCommon
 
@@ -106,6 +107,36 @@ class TestRMALot(BaseCommon):
         rma_lot_1, rma_lot_2 = self.test_00()
         self.assertEqual(rma_lot_1.delivery_move_ids.restrict_lot_id, self.lot_1)
         self.assertEqual(rma_lot_2.delivery_move_ids.restrict_lot_id, self.lot_2)
+
+    @mute_logger("odoo.models.unlink")
+    def test_deliver_same_lot_as_received_extra(self):
+        self.operation.deliver_same_lot = True
+        self.operation.action_create_delivery = "manual_after_receipt"
+        rma_lot_1, rma_lot_2 = self.test_00()
+        # TODO: This shouldn't be necessary
+        rma_lot_1.product_uom_qty = 1
+        rma_lot_1.reception_move_id.move_line_ids.filtered(
+            lambda x: x.lot_id == self.lot_2
+        ).unlink()
+        reception_picking = rma_lot_1.reception_move_id.picking_id
+        wiz_act = reception_picking.button_validate()
+        wiz = Form(
+            self.env[wiz_act["res_model"]].with_context(**wiz_act["context"])
+        ).save()
+        wiz.process()
+        self.assertEqual(reception_picking.state, "done")
+        self.assertEqual(rma_lot_1.state, "received")
+        self.assertEqual(rma_lot_2.state, "received")
+        rma_lot_1.lot_id = self.lot_2
+        rma_lot_1.create_return(
+            fields.Datetime.now(),
+            rma_lot_1.product_uom_qty,
+            rma_lot_1.product_uom,
+        )
+        delivery_picking = rma_lot_1.delivery_move_ids.picking_id
+        self.assertEqual(delivery_picking.state, "assigned")
+        delivery_picking.button_validate()
+        self.assertEqual(delivery_picking.state, "done")
 
     def test_deliver_different_lot_as_received(self):
         self.operation.deliver_same_lot = False


### PR DESCRIPTION
Do not define `move_orig_ids` with other lot to avoid inconsistencies

Please @pedrobaeza and  @carlos-lopez-tecnativa can you review it?

@Tecnativa TT61741