### PR TITLE
[16.0][FIX] rma_repair: correct visibility logic for RMA smart button

### DIFF
--- a/rma_repair/models/repair.py
+++ b/rma_repair/models/repair.py
@@ -1,7 +1,7 @@
 # Copyright 2024 APSL-Nagarro Antoni Marroig
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class RepairOrder(models.Model):
@@ -12,6 +12,13 @@ class RepairOrder(models.Model):
         inverse_name="repair_id",
         string="RMAs",
     )
+
+    rma_count = fields.Integer(compute="_compute_rma_count")
+
+    @api.depends("rma_ids")
+    def _compute_rma_count(self):
+        for record in self:
+            record.rma_count = len(record.rma_ids)
 
     def action_view_repair_rma(self):
         return {

--- a/rma_repair/views/repair_views.xml
+++ b/rma_repair/views/repair_views.xml
@@ -14,11 +14,9 @@
                     name="action_view_repair_rma"
                     type="object"
                     icon="fa-rotate-left"
-                    attrs="{'invisible': [('rma_ids', '=', False)]}"
+                    attrs="{'invisible': [('rma_count', '=', 0)]}"
                 >
-                    <div class="o_field_widget o_stat_info">
-                        <span class="o_stat_text">RMA</span>
-                    </div>
+                    <field string="RMA" name="rma_count" widget="statinfo" />
                 </button>
             </xpath>
         </field>


### PR DESCRIPTION
The RMA smart button used an 'invisible' condition checking for 'rma_ids' = False. In Odoo, relational fields (One2many/Many2many) return an empty recordset rather than False, causing the button to remain visible even when empty.

This PR:
- Adds a computed 'rma_count' field to the repair order model.
- Updates the XML to use 'rma_count' for the 'invisible' attribute.
- Improves UI feedback by displaying the record count within the stat button.

(This follows a pattern for smart buttons that can be found in many other places)

<img width="303" height="46" alt="image" src="https://github.com/user-attachments/assets/cb83e9da-061c-41bd-8e71-d726d8a523c8" />
