### PR TITLE
[18.0][FIX] checklog-odoo.cfg: ignore Killing chrome descendants-or-self warning

### DIFF
--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,4 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING .* Killing chrome descendants-or-self .*


### PR DESCRIPTION
Related to https://github.com/OCA/web/pull/3507

Warning introduced in odoo/odoo@d22e0b4. The previous warning apparently did not occur, as it was not featured in checklog-odoo.cfg.

```
2026-04-13 08:02:23,361 314 WARNING odoo odoo.addons.rma_sale_mrp.tests.test_rma_sale_mrp_portal.TestRmaSaleMrpPortal.test_rma_sale_mrp_portal: Killing chrome descendants-or-self of 450: 5 remaining
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)