### PR TITLE
[16.0][FIX] rma_repair: prevent automatic assignment of responsible on repair

### DIFF
--- a/rma_repair/models/rma.py
+++ b/rma_repair/models/rma.py
@@ -69,6 +69,7 @@ class RMA(models.Model):
             "default_address_id": self.partner_shipping_id.id,
             "default_partner_invoice_id": self.partner_invoice_id.id,
             "default_picking_id": self.reception_move_id.picking_id.id,
+            "default_user_id": False,
         }
         if self.lot_id:
             vals["default_lot_id"] = self.lot_id.id
@@ -97,11 +98,13 @@ class RMA(models.Model):
         self.ensure_one()
         if self.repair_id:
             return self.repair_id
-        return (
+        repair = (
             self.env["repair.order"]
             .with_context(**self._get_repair_order_default_vals())
-            .create({})
+            .create({"user_id": False})
         )
+
+        return repair
 
     def action_confirm(self):
         res = super().action_confirm()

--- a/rma_repair/models/rma.py
+++ b/rma_repair/models/rma.py
@@ -7,7 +7,7 @@ from odoo import _, api, fields, models
 class RMA(models.Model):
     _inherit = "rma"
 
-    repair_id = fields.Many2one("repair.order")
+    repair_id = fields.Many2one("repair.order", copy=False)
     can_be_repaired = fields.Boolean(compute="_compute_can_be_repaired")
 
     @api.depends("repair_id", "state", "operation_id.action_create_repair")

--- a/rma_repair/tests/test_rma_repair_order.py
+++ b/rma_repair/tests/test_rma_repair_order.py
@@ -60,6 +60,7 @@ class RMARepairOrderTest(TransactionCase):
             "default_address_id": self.rma.partner_shipping_id.id,
             "default_partner_invoice_id": self.rma.partner_invoice_id.id,
             "default_picking_id": self.rma.reception_move_id.picking_id.id,
+            "default_user_id": False,
         }
         for key, expected_value in expected.items():
             self.assertIn(key, ctx, f"Missing context key: {key}")
@@ -179,3 +180,18 @@ class RMARepairOrderTest(TransactionCase):
         self.assertFalse(self.rma_without_repair.can_be_repaired)
         self.assertTrue(self.rma_without_repair.repair_id)
         self.assertFalse(self.rma_without_repair.can_be_repaired)
+
+    def test_rma_repair_no_defualt_user_id(self):
+        """
+        Ensure repair order create from RMA is not assigned a responsible.
+
+        Rationale:
+        The customer service agent confirming the RMA is often not
+        part of the technical repair team. Automatically assigning the RMA
+        validator as the repair responsible would create unwanted notifications.
+        """
+        rma = self.rma.copy()
+        rma.operation_id.action_create_repair = "automatic_on_confirm"
+        rma.action_confirm()
+        self.assertTrue(rma.repair_id)
+        self.assertFalse(rma.repair_id.user_id)


### PR DESCRIPTION
The `repair.order` model defaults `user_id` to the current user. Since RMA processing and technical repairs could be handled by different teams, automatically assigning the customer service agent to the repair order is incorrect.