### PR TITLE
[18.0][FIX] rma_sale_delivery: Use proper available carriers method

### DIFF
--- a/rma_sale_delivery/wizard/sale_order_rma_wizard.py
+++ b/rma_sale_delivery/wizard/sale_order_rma_wizard.py
@@ -32,7 +32,7 @@ class SaleOrderRmaWizard(models.TransientModel):
                 carrier_model._check_company_domain(item.company_id)
             )
             item.available_reception_carrier_ids = (
-                carriers.available_carriers_rma(partner, item.order_id)
+                carriers.available_carriers(partner, item.order_id)
                 if partner
                 else carriers
             )


### PR DESCRIPTION
We can't use the RMA one, as it doesn't exist yet. Not sure though if the sales order check is enough, or there should be something more, as this is a return.

@Tecnativa TT62250