### PR TITLE
[18.0][IMP] rma_delivery: Use the rma_id in the available_carriers_rma() method to avoid errors

### DIFF
--- a/rma_delivery/wizard/rma_rma_wizard.py
+++ b/rma_delivery/wizard/rma_rma_wizard.py
@@ -39,7 +39,7 @@ class RmaRmaWizard(models.TransientModel):
                 carrier_model._check_company_domain(item.company_id)
             )
             item.available_reception_carrier_ids = (
-                carriers.available_carriers_rma(item.partner_shipping_id, item)
+                carriers.available_carriers_rma(item.partner_shipping_id, item.rma_id)
                 if item.partner_shipping_id
                 else carriers
             )


### PR DESCRIPTION
Use the `rma_id` in the `available_carriers_rma()` method to avoid errors

```
tag in rma.product_id.all_product_tag_ids for tag in self.excluded_tag_ids
    AttributeError: 'rma.rma.wizard' object has no attribute 'product_id'
```

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT62412