### PR TITLE
[IMP] rma_sale: manually link RMAs to sale orders

### DIFF
--- a/rma_sale/__manifest__.py
+++ b/rma_sale/__manifest__.py
@@ -23,6 +23,7 @@
         "views/sale_portal_template.xml",
         "views/res_config_settings_views.xml",
         "wizard/sale_order_rma_wizard_views.xml",
+        "wizard/rma_sale_order_link_wizard.xml",
     ],
     "assets": {
         "web.assets_frontend": [

--- a/rma_sale/i18n/fr.po
+++ b/rma_sale/i18n/fr.po
@@ -120,6 +120,7 @@ msgid "Allowed Quantity"
 msgstr ""
 
 #. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.rma_sale_order_link_wizard_form_view
 #: model_terms:ir.ui.view,arch_db:rma_sale.sale_order_rma_wizard_form_view
 msgid "Cancel"
 msgstr "Annuler"
@@ -159,6 +160,11 @@ msgid "Config Settings"
 msgstr "Paramètres de configuration"
 
 #. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.rma_sale_order_link_wizard_form_view
+msgid "Confirm"
+msgstr "Confirmer"
+
+#. module: rma_sale
 #: model:ir.model.fields,help:rma_sale.field_sale_order_line_rma_wizard__uom_category_id
 msgid ""
 "Conversion between Units of Measure can only occur if they belong to the "
@@ -182,12 +188,14 @@ msgid "Create RMAs"
 msgstr "Créer RMA"
 
 #. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_sale_order_link_wizard__create_uid
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_line_rma_wizard__create_uid
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_rma_wizard__create_uid
 msgid "Created by"
 msgstr "Créé par"
 
 #. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_sale_order_link_wizard__create_date
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_line_rma_wizard__create_date
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_rma_wizard__create_date
 msgid "Created on"
@@ -197,6 +205,11 @@ msgstr "Créé le"
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_rma_wizard__custom_description
 msgid "Custom Description"
 msgstr "Description personnalisée"
+
+#. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_sale_order_link_wizard__partner_id
+msgid "Customer"
+msgstr "Client"
 
 #. module: rma_sale
 #: model_terms:ir.ui.view,arch_db:rma_sale.sale_rma_request_form
@@ -219,6 +232,7 @@ msgid "Different Return Product"
 msgstr ""
 
 #. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_sale_order_link_wizard__display_name
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_line_rma_wizard__display_name
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_rma_wizard__display_name
 msgid "Display Name"
@@ -241,6 +255,7 @@ msgid "Full page RMA creation"
 msgstr "Création RMA pleine page"
 
 #. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_sale_order_link_wizard__id
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_line_rma_wizard__id
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_rma_wizard__id
 msgid "ID"
@@ -266,18 +281,21 @@ msgid "Journal Entry"
 msgstr "Pièce comptable"
 
 #. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_sale_order_link_wizard____last_update
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_line_rma_wizard____last_update
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_rma_wizard____last_update
 msgid "Last Modified on"
 msgstr "Dernière modification le"
 
 #. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_sale_order_link_wizard__write_uid
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_line_rma_wizard__write_uid
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_rma_wizard__write_uid
 msgid "Last Updated by"
 msgstr "Dernière modification par"
 
 #. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_sale_order_link_wizard__write_date
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_line_rma_wizard__write_date
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_rma_wizard__write_date
 msgid "Last Updated on"
@@ -287,6 +305,14 @@ msgstr ""
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_rma_wizard__line_ids
 msgid "Lines"
 msgstr "Lignes"
+
+#. module: rma_sale
+#. odoo-python
+#: code:addons/rma_sale/models/rma.py:0
+#: model_terms:ir.ui.view,arch_db:rma_sale.rma_view_form
+#, python-format
+msgid "Link to sale order"
+msgstr "Lier à la commande client"
 
 #. module: rma_sale
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_line_rma_wizard__move_id
@@ -387,6 +413,16 @@ msgid "Return Product"
 msgstr ""
 
 #. module: rma_sale
+#: model:ir.model.fields,field_description:rma_sale.field_rma_sale_order_link_wizard__rma_id
+msgid "Rma"
+msgstr ""
+
+#. module: rma_sale
+#: model_terms:ir.ui.view,arch_db:rma_sale.rma_sale_order_link_wizard_form_view
+msgid "Rma Sale Order Link Wizard"
+msgstr ""
+
+#. module: rma_sale
 #: model:ir.model.fields,field_description:rma_sale.field_rma__sale_line_id
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_line_rma_wizard__sale_line_id
 msgid "Sale Line"
@@ -394,8 +430,16 @@ msgstr "Ligne de commande"
 
 #. module: rma_sale
 #: model:ir.model.fields,field_description:rma_sale.field_rma__order_id
+#: model:ir.model.fields,field_description:rma_sale.field_rma_sale_order_link_wizard__sale_order_id
 msgid "Sale Order"
 msgstr "Bon de commande"
+
+#. module: rma_sale
+#. odoo-python
+#: code:addons/rma_sale/wizard/rma_sale_order_link_wizard.py:0
+#, python-format
+msgid "Sale Order %(order)s linked manually."
+msgstr "Commande client %(order)s liée manuellement."
 
 #. module: rma_sale
 #: model:ir.model,name:rma_sale.model_sale_order_line_rma_wizard
@@ -487,6 +531,11 @@ msgstr "Sera utilisé pour retourner les marchandises une fois le RMA terminé"
 #. module: rma_sale
 #: model:ir.model.fields,field_description:rma_sale.field_sale_order_line_rma_wizard__wizard_id
 msgid "Wizard"
+msgstr ""
+
+#. module: rma_sale
+#: model:ir.model,name:rma_sale.model_rma_sale_order_link_wizard
+msgid "Wizard to link existing rma to sale order"
 msgstr ""
 
 #. module: rma_sale

--- a/rma_sale/models/rma.py
+++ b/rma_sale/models/rma.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.tools import float_compare
 
 
@@ -219,3 +219,14 @@ class Rma(models.Model):
         new_moves = self.delivery_move_ids - moves_before
         new_moves.picking_id.sale_id = False
         return res
+
+    def action_link_to_sale_order(self):
+        self.ensure_one()
+        return {
+            "name": _("Link to sale order"),
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "res_model": "rma.sale.order.link.wizard",
+            "target": "new",
+            "context": {"default_rma_id": self.id, **self.env.context},
+        }

--- a/rma_sale/security/ir.model.access.csv
+++ b/rma_sale/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_sale_order_rma_wizard_user_all,sale.order.rma.wizard.user.all,model_sale_order_rma_wizard,rma.rma_group_user_all,1,1,1,1
 access_sale_order_line_rma_wizard_user_all,sale.order.line.rma.wizard.user.all,model_sale_order_line_rma_wizard,rma.rma_group_user_all,1,1,1,1
+access_rma_sale_order_link_wizard_user_all,sale.order.rma.wizard.user.all,model_rma_sale_order_link_wizard,rma.rma_group_user_all,1,1,1,1

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -336,3 +336,24 @@ class TestRmaSale(TestRmaSaleBase):
         rmas = self.env["rma"].search(wizard.create_and_open_rma()["domain"])
         self.assertEqual(len(rmas.reception_move_id.group_id), 1)
         self.assertEqual(len(rmas.reception_move_id.picking_id), 1)
+
+    def test_link_to_sale_order(self):
+        rma_vals = {
+            "partner_id": self.partner.id,
+            "product_id": self.product_1.id,
+            "product_uom_qty": 5,
+            "location_id": self.sale_order.warehouse_id.rma_loc_id.id,
+            "operation_id": self.operation.id,
+        }
+        rma = self.env["rma"].create(rma_vals)
+        rma.action_confirm()
+        action = rma.action_link_to_sale_order()
+        wizard = (
+            self.env[action.get("res_model")]
+            .with_context(**action.get("context"))
+            .create({"sale_order_id": self.sale_order.id})
+        )
+        self.assertEqual(wizard.rma_id, rma)
+        self.assertFalse(rma.order_id)
+        wizard.action_link_rma_to_sale_order()
+        self.assertEqual(rma.order_id, self.sale_order)

--- a/rma_sale/views/rma_views.xml
+++ b/rma_sale/views/rma_views.xml
@@ -7,6 +7,14 @@
         <field name="model">rma</field>
         <field name="inherit_id" ref="rma.rma_view_form" />
         <field name="arch" type="xml">
+            <header position="inside">
+                <button
+                    name="action_link_to_sale_order"
+                    type="object"
+                    string="Link to sale order"
+                    attrs="{'invisible': [('move_id', '!=', False)]}"
+                />
+            </header>
             <field name="partner_invoice_id" position="after">
                 <field
                     name="order_id"

--- a/rma_sale/wizard/__init__.py
+++ b/rma_sale/wizard/__init__.py
@@ -2,3 +2,4 @@
 
 from . import sale_order_rma_wizard
 from . import stock_picking_return
+from . import rma_sale_order_link_wizard

--- a/rma_sale/wizard/rma_sale_order_link_wizard.py
+++ b/rma_sale/wizard/rma_sale_order_link_wizard.py
@@ -1,0 +1,29 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, fields, models
+
+
+class RmaSaleOrderLinkWizard(models.TransientModel):
+
+    _name = "rma.sale.order.link.wizard"
+    _description = "Wizard to link existing rma to sale order"
+
+    rma_id = fields.Many2one(comodel_name="rma")
+    partner_id = fields.Many2one(related="rma_id.partner_id")
+    sale_order_id = fields.Many2one(
+        comodel_name="sale.order",
+        string="Sale Order",
+        required=True,
+        ondelete="cascade",
+        domain="[('partner_id', '=', partner_id), ('state', 'in', ('sale', 'done'))]",
+    )
+
+    def action_link_rma_to_sale_order(self):
+        self.ensure_one()
+        self.rma_id.order_id = self.sale_order_id
+        self.rma_id.message_post(
+            body=_(
+                "Sale Order %(order)s linked manually.", order=self.sale_order_id.name
+            )
+        )

--- a/rma_sale/wizard/rma_sale_order_link_wizard.xml
+++ b/rma_sale/wizard/rma_sale_order_link_wizard.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 ACSONE SA/NV
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="rma_sale_order_link_wizard_form_view">
+        <field name="model">rma.sale.order.link.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Rma Sale Order Link Wizard">
+                <group>
+                    <field name="rma_id" invisible="1" />
+                    <field name="partner_id" readonly="True" />
+                    <field name="sale_order_id" />
+                </group>
+                <footer>
+                    <button
+                        name="action_link_rma_to_sale_order"
+                        string="Confirm"
+                        class="btn-primary"
+                        type="object"
+                    />
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+
+
+</odoo>


### PR DESCRIPTION
In some cases, RMAs need to be created before the related sale order is known. This commit allows manually linking the RMA to a sale order afterward to improve traceability