### PR TITLE
[18.0][IMP] rma_sale: Set fiscal_position_id on the refund invoice

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -1234,6 +1234,7 @@ class Rma(models.Model):
             "move_type": "out_refund",
             "company_id": self.company_id.id,
             "partner_id": self.partner_invoice_id.id,
+            "partner_shipping_id": self.partner_shipping_id.id,
             "invoice_payment_term_id": False,
             "invoice_origin": origin,
             "invoice_line_ids": [],

--- a/rma_sale/models/rma.py
+++ b/rma_sale/models/rma.py
@@ -134,11 +134,19 @@ class Rma(models.Model):
         return res
 
     def _prepare_refund_vals(self, origin=False):
-        """Inject salesman from sales order (if any)"""
+        """Inject fiscal_position_id + salesman from sales order (if any)"""
         vals = super()._prepare_refund_vals(origin=origin)
         order = self.sudo().order_id
         if order:
             vals["invoice_user_id"] = order.user_id.id
+            # It is important to set the correct fiscal position for the sales order
+            # when creating the invoice, just as it is done in sale
+            vals["fiscal_position_id"] = (
+                order.fiscal_position_id
+                or order.fiscal_position_id._get_fiscal_position(
+                    self.partner_invoice_id
+                )
+            ).id
         return vals
 
     def _prepare_refund_line_vals(self):


### PR DESCRIPTION
Changes done:
- [x] `rma`: Add partner_shipping_id to refund invoice
- [x] rma_sale: Set fiscal_position_id on the refund invoice

Please @carlosdauden, @carlos-lopez-tecnativa  and @pedrobaeza can you review it?

@Tecnativa TT62787 TT62768