### PR TITLE
[18.0][IMP] rma + rma_sale: Add new rma compatibility

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -710,6 +710,7 @@ class Rma(models.Model):
     # Action methods
     def action_create_rma(self):
         self.ensure_one()
+        self._ensure_can_be_new_rma()
         action = self.env["ir.actions.act_window"]._for_xml_id(
             "rma.rma_create_rma_action"
         )
@@ -1098,6 +1099,15 @@ class Rma(models.Model):
                 desc += f"\n{field_record.field_description}"
             if desc:
                 raise ValidationError(self.env._("Required field(s):%s") % desc)
+
+    def _ensure_can_be_new_rma(self):
+        if len(self) == 1:
+            if not self.can_be_new_rma:
+                raise ValidationError(self.env._("This RMA cannot perform a new RMA."))
+        elif not self.filtered("can_be_new_rma"):
+            raise ValidationError(
+                self.env._("None of the selected RMAs can perform a new RMA.")
+            )
 
     def _ensure_can_be_returned(self):
         """This method is intended to be invoked after user click on

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -338,6 +338,7 @@ class TestRmaCase(TestRma):
         self.assertEqual(rma.state, "confirmed")
 
     def test_confirm_and_receive_and_return(self):
+        self.company.rma_new_rma_button_from_rma = True
         rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
         rma.action_confirm()
         self.assertEqual(rma.reception_move_id.picking_id.state, "assigned")

--- a/rma_sale/models/rma.py
+++ b/rma_sale/models/rma.py
@@ -137,6 +137,9 @@ class Rma(models.Model):
         """Inject fiscal_position_id + salesman from sales order (if any)"""
         vals = super()._prepare_refund_vals(origin=origin)
         order = self.sudo().order_id
+        if not order and self.move_id.rma_id:
+            # We use the RMA from which it was created
+            order = self.move_id.rma_id.sudo().order_id
         if order:
             vals["invoice_user_id"] = order.user_id.id
             # It is important to set the correct fiscal position for the sales order
@@ -156,6 +159,9 @@ class Rma(models.Model):
         """
         vals = super()._prepare_refund_line_vals()
         line = self.sudo().sale_line_id
+        if not line and self.move_id.rma_id:
+            # We use the RMA from which it was created
+            line = self.move_id.rma_id.sudo().sale_line_id
         if line:
             vals["product_id"] = line.product_id.id
             vals["price_unit"] = line.price_unit

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -143,6 +143,46 @@ class TestRmaSale(TestRmaSaleBase):
         self.assertEqual(len(self.sale_order.order_line), 1)
 
     @mute_logger("odoo.models.unlink")
+    def test_rma_rma_refund_from_so(self):
+        self.operation.action_create_delivery = "manual_after_receipt"
+        self.operation.action_create_refund = "manual_after_receipt"
+        self.company.rma_new_rma_button_from_rma = True
+        order = self.sale_order
+        order.user_id = self.user_rma
+        wizard = self._rma_sale_wizard(order)
+        rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
+        self.assertEqual(rma.order_id, order)
+        rma.reception_move_id.quantity = rma.product_uom_qty
+        rma.reception_move_id.picking_id.button_validate()
+        self.assertEqual(rma.state, "received")
+        res = rma.action_return()
+        wizard_form = Form(self.env[res["res_model"]].with_context(**res["context"]))
+        wizard = wizard_form.save()
+        wizard.action_deliver()
+        picking = rma.delivery_move_ids.picking_id
+        picking.move_ids.quantity = rma.product_uom_qty
+        picking.button_validate()
+        self.assertEqual(rma.state, "returned")
+        self.assertTrue(rma.can_be_new_rma)
+        res = rma.action_create_rma()
+        wizard_form = Form(self.env[res["res_model"]].with_context(**res["context"]))
+        wizard = wizard_form.save()
+        rma_extra = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
+        self.assertFalse(rma_extra.order_id)
+        rma_extra.reception_move_id.quantity = rma_extra.product_uom_qty
+        rma_extra.reception_move_id.picking_id.button_validate()
+        self.assertEqual(rma_extra.state, "received")
+        rma_extra.action_refund()
+        self.assertEqual(rma_extra.state, "refunded")
+        self.assertTrue(rma_extra.refund_line_id.sale_line_ids)
+        self.assertEqual(rma_extra.refund_id.invoice_user_id, self.user_rma)
+        self.assertFalse(rma_extra.can_be_new_rma)
+        with self.assertRaisesRegex(
+            ValidationError, "This RMA cannot perform a new RMA."
+        ):
+            rma_extra.action_create_rma()
+
+    @mute_logger("odoo.models.unlink")
     def test_create_rma_from_so(self):
         self.operation.action_create_refund = "manual_after_receipt"
         order = self.sale_order


### PR DESCRIPTION
Add new rma compatibility

Use case example:
- Create a sales order
- Confirm the sales order + done picking
- Create RMA 1 from the sales order
- Done reception picking of RMA 1 + return to the customer + done delivery picking for RMA 1
- Create RMA 2 from RMA 1
- Done reception picking of RMA 2
- Refund RMA 2
- Credit note must be linked to the sales order

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT62775