### PR TITLE
[16.0][FIX] rma: Cancel delivery moves when canceling the RMA

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -1007,6 +1007,7 @@ class Rma(models.Model):
     def action_cancel(self):
         """Invoked when 'Cancel' button in rma form view is clicked."""
         self.reception_move_id._action_cancel()
+        self.delivery_move_ids._action_cancel()
         self.write({"state": "cancelled"})
 
     def action_draft(self):

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -300,7 +300,8 @@ class TestRmaCase(TestRma):
         self.assertEqual(rma.reception_move_id.quantity_done, 10)
         self.assertEqual(rma.state, "received")
 
-    def test_cancel(self):
+    @mute_logger("odoo.models.unlink")
+    def test_cancel_01(self):
         # cancel a draft RMA
         rma = self._create_rma(self.partner, self.product)
         rma.action_cancel()
@@ -314,6 +315,27 @@ class TestRmaCase(TestRma):
         rma = self._create_confirm_receive(self.partner, self.product, 10, self.rma_loc)
         with self.assertRaises(UserError):
             rma.action_cancel()
+
+    @mute_logger("odoo.models.unlink")
+    def test_cancel_02(self):
+        self.operation.action_create_delivery = "manual_on_confirm"
+        rma = self._create_rma(self.partner, self.product)
+        rma.action_confirm()
+        self.assertEqual(rma.state, "confirmed")
+        reception_picking = rma.reception_move_id.picking_id
+        self.assertEqual(reception_picking.state, "assigned")
+        res = rma.action_replace()
+        delivery_form = Form(self.env[res["res_model"]].with_context(**res["context"]))
+        delivery_form.product_id = self.product
+        delivery_wizard = delivery_form.save()
+        delivery_wizard.action_deliver()
+        self.assertEqual(rma.state, "waiting_replacement")
+        delivery_picking = rma.delivery_move_ids.picking_id
+        self.assertEqual(delivery_picking.state, "confirmed")
+        rma.action_cancel()
+        self.assertEqual(rma.state, "cancelled")
+        self.assertEqual(reception_picking.state, "cancel")
+        self.assertEqual(delivery_picking.state, "cancel")
 
     def test_lock_unlock(self):
         # A RMA is only locked from 'received' state


### PR DESCRIPTION
Backport from 17.0: https://github.com/OCA/rma/pull/593

Cancel delivery moves when canceling the RMA

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT62752