### PR TITLE
[18.0][IMP] rma_sale: Refund compatibility with not invoiced orders

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -178,7 +178,7 @@ class Rma(models.Model):
             ("received", "Received"),
             ("waiting_return", "Waiting for return"),
             ("waiting_replacement", "Waiting for replacement"),
-            ("refunded", "Refunded"),
+            ("refunded", "Refunded/Not invoiceable"),
             ("returned", "Returned"),
             ("replaced", "Replaced"),
             ("finished", "Finished"),

--- a/rma_sale/models/rma.py
+++ b/rma_sale/models/rma.py
@@ -127,10 +127,23 @@ class Rma(models.Model):
 
         NOTE: The refund line is linked to the SO line in `_prepare_refund_line`.
         """
+        _self = self
+        # Do not generate a refund invoice if the sales line has not yet been invoiced
+        # or if it is an RMA created from another RMA with the same condition
+        not_refundable = self.filtered(
+            lambda x: (x.sale_line_id and not x.sale_line_id.invoice_lines)
+            or (
+                x.move_id.rma_id.sale_line_id
+                and not x.move_id.rma_id.sale_line_id.invoice_lines
+            )
+        )
+        self -= not_refundable
         res = super().action_refund()
-        for rma in self:
+        for rma in _self:
             if rma.sale_line_id:
                 rma._link_refund_with_reception_move()
+        # These RMAs should be set to this state anyway
+        not_refundable.state = "refunded"
         return res
 
     def _prepare_refund_vals(self, origin=False):

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -147,8 +147,13 @@ class TestRmaSale(TestRmaSaleBase):
         self.operation.action_create_delivery = "manual_after_receipt"
         self.operation.action_create_refund = "manual_after_receipt"
         self.company.rma_new_rma_button_from_rma = True
+        self.product_1.invoice_policy = "delivery"
         order = self.sale_order
         order.user_id = self.user_rma
+        order._create_invoices()
+        self.assertEqual(order.invoice_status, "invoiced")
+        self.assertEqual(self.order_line.qty_delivered, 5)
+        self.assertEqual(self.order_line.qty_invoiced, 5)
         wizard = self._rma_sale_wizard(order)
         rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
         self.assertEqual(rma.order_id, order)
@@ -183,9 +188,14 @@ class TestRmaSale(TestRmaSaleBase):
             rma_extra.action_create_rma()
 
     @mute_logger("odoo.models.unlink")
-    def test_create_rma_from_so(self):
+    def test_create_rma_from_so_with_invoice(self):
         self.operation.action_create_refund = "manual_after_receipt"
+        self.product_1.invoice_policy = "delivery"
         order = self.sale_order
+        order._create_invoices()
+        self.assertEqual(order.invoice_status, "invoiced")
+        self.assertEqual(self.order_line.qty_delivered, 5)
+        self.assertEqual(self.order_line.qty_invoiced, 5)
         wizard = self._rma_sale_wizard(order)
         rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
         self.assertEqual(rma.partner_id, order.partner_id)
@@ -213,17 +223,61 @@ class TestRmaSale(TestRmaSaleBase):
         # Refund the RMA
         rma.action_refund()
         self.assertEqual(self.order_line.qty_delivered, 0)
-        self.assertEqual(self.order_line.qty_invoiced, -5)
+        self.assertEqual(self.order_line.qty_invoiced, 0)
         self.assertEqual(rma.refund_id.user_id, user)
         self.assertEqual(rma.refund_id.invoice_line_ids.sale_line_ids, self.order_line)
+        self.assertEqual(order.invoice_status, "no")
         # Cancel the refund
         rma.refund_id.button_cancel()
         self.assertEqual(self.order_line.qty_delivered, 5)
-        self.assertEqual(self.order_line.qty_invoiced, 0)
+        self.assertEqual(self.order_line.qty_invoiced, 5)
+        self.assertEqual(order.invoice_status, "invoiced")
         # And put it to draft again
         rma.refund_id.button_draft()
         self.assertEqual(self.order_line.qty_delivered, 0)
-        self.assertEqual(self.order_line.qty_invoiced, -5)
+        self.assertEqual(self.order_line.qty_invoiced, 0)
+        self.assertEqual(order.invoice_status, "no")
+        self.assertEqual(rma.state, "refunded")
+
+    @mute_logger("odoo.models.unlink")
+    def test_create_rma_from_so_without_invoice(self):
+        self.operation.action_create_refund = "manual_after_receipt"
+        self.product_1.invoice_policy = "delivery"
+        order = self.sale_order
+        self.assertEqual(order.invoice_status, "to invoice")
+        self.assertEqual(self.order_line.qty_delivered, 5)
+        self.assertEqual(self.order_line.qty_invoiced, 0)
+        wizard = self._rma_sale_wizard(order)
+        rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
+        self.assertEqual(rma.partner_id, order.partner_id)
+        self.assertEqual(rma.order_id, order)
+        self.assertEqual(rma.picking_id, self.order_out_picking)
+        self.assertEqual(rma.move_id, self.order_out_picking.move_ids)
+        self.assertEqual(rma.product_id, self.product_1)
+        self.assertEqual(rma.product_uom_qty, self.order_line.product_uom_qty)
+        self.assertEqual(rma.product_uom, self.order_line.product_uom)
+        self.assertEqual(rma.state, "confirmed")
+        self.assertEqual(
+            rma.reception_move_id.origin_returned_move_id,
+            self.order_out_picking.move_ids,
+        )
+        self.assertEqual(
+            rma.reception_move_id.picking_id + self.order_out_picking,
+            order.picking_ids,
+        )
+        user = new_test_user(self.env, login="test_refund_with_so")
+        order.user_id = user.id
+        # Receive the RMA
+        rma.action_confirm()
+        rma.reception_move_id.quantity = rma.product_uom_qty
+        rma.reception_move_id.picking_id.button_validate()
+        # Refund the RMA
+        rma.action_refund()
+        self.assertEqual(self.order_line.qty_delivered, 0)
+        self.assertEqual(self.order_line.qty_invoiced, 0)
+        self.assertFalse(rma.refund_id)
+        self.assertEqual(order.invoice_status, "no")
+        self.assertEqual(rma.state, "refunded")
 
     @users("partner@rma")
     def test_create_rma_from_so_portal_user(self):

--- a/rma_sale_mrp/tests/test_rma_sale_mrp.py
+++ b/rma_sale_mrp/tests/test_rma_sale_mrp.py
@@ -2,8 +2,10 @@
 # Copyright 2022 Tecnativa - Víctor Martínez
 # Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import Command
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import Form
+from odoo.tools import mute_logger
 
 from odoo.addons.rma_sale.tests.test_rma_sale import TestRmaSaleBase
 
@@ -27,14 +29,10 @@ class TestRmaSaleMrpBase(TestRmaSaleBase):
                 "product_tmpl_id": cls.product_kit.product_tmpl_id.id,
                 "type": "phantom",
                 "bom_line_ids": [
-                    (
-                        0,
-                        0,
+                    Command.create(
                         {"product_id": cls.product_kit_comp_1.id, "product_qty": 2},
                     ),
-                    (
-                        0,
-                        0,
+                    Command.create(
                         {"product_id": cls.product_kit_comp_2.id, "product_qty": 4},
                     ),
                 ],
@@ -68,9 +66,12 @@ class TestRmaSaleMrpBase(TestRmaSaleBase):
 
 
 class TestRmaSaleMrp(TestRmaSaleMrpBase):
+    @mute_logger("odoo.models.unlink")
     def test_create_rma_from_so(self):
         self.operation.action_create_refund = "manual_after_receipt"
+        self.product_kit_comp_2.invoice_policy = "delivery"
         order = self.sale_order
+        order._create_invoices()
         out_pickings = self.order_out_picking + self.backorder
         wizard = self._rma_sale_wizard(order)
         wizard.line_ids.quantity = 4
@@ -139,6 +140,7 @@ class TestRmaSaleMrp(TestRmaSaleMrpBase):
         with self.assertRaises(ValidationError):
             wizard.line_ids.quantity = 2
 
+    @mute_logger("odoo.models.unlink")
     def test_report_rma(self):
         wizard = self._rma_sale_wizard(self.sale_order)
         wizard.line_ids.quantity = 4


### PR DESCRIPTION
Changes done:
- [x] Refund compatibility with not invoiced orders
- [x] Change refunded label state to Refunded/Not invoiceable

Use case example:
- Define product with Invoicing Policy: Delivered quantities
- Create sale order + Validate picking
- Create RMA + Validate incoming picking
- Refund action on the RMA
- Refund invoice will NOT be created

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT62394