### PR TITLE
[16.0][IMP] rma: Define the appropriate origin for the reception picking (similar to v15)

### DIFF
--- a/rma/models/stock_move.py
+++ b/rma/models/stock_move.py
@@ -123,6 +123,21 @@ class StockMove(models.Model):
             res["rma_id"] = self.rma_id.id
         return res
 
+    def _get_new_picking_values(self):
+        # For reception pickings created from an RMA, if the RMA is linked to a
+        # picking_id, we don't want to lose the stock information from the return
+        # pick (Return of WH/OUT/001)
+        values = super()._get_new_picking_values()
+        if self.rma_receiver_ids and all(
+            rma.picking_id for rma in self.rma_receiver_ids
+        ):
+            origin = values["origin"]
+            pickings = self.rma_receiver_ids.picking_id
+            picking_name = self and ", ".join(pickings.mapped("name"))
+            new_origin = "{} ({})".format(origin, _("Return of %s") % picking_name)
+            values["origin"] = new_origin
+        return values
+
 
 class StockRule(models.Model):
     _inherit = "stock.rule"

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -357,6 +357,8 @@ class TestRmaCase(TestRma):
     @users("__system__", "user_rma")
     def test_action_refund(self):
         rma = self._create_confirm_receive(self.partner, self.product, 10, self.rma_loc)
+        reception_picking = rma.reception_move_id.picking_id
+        self.assertEqual(reception_picking.origin, rma.name)
         self.assertEqual(rma.state, "received")
         self.assertTrue(rma.can_be_refunded)
         self.assertTrue(rma.can_be_returned)
@@ -780,6 +782,10 @@ class TestRmaCase(TestRma):
         rma_form.operation_id = self.operation
         rma = rma_form.save()
         rma.action_confirm()
+        reception_picking = rma.reception_move_id.picking_id
+        self.assertEqual(
+            reception_picking.origin, f"{rma.name} (Return of {origin_delivery.name})"
+        )
         rma.reception_move_id.quantity_done = 10
         rma.reception_move_id.picking_id._action_done()
         # Return quantity 4 of the same product to the customer


### PR DESCRIPTION
Define the appropriate origin for the reception picking (similar to v15)

https://github.com/OCA/rma/blob/4e2b32df7f679d1e1ddf43ea3c3c526c0fd0bafc/rma/models/rma.py#L1007

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT63073