### PR TITLE
[18.0][FIX] rma: References block layout & spacing

### DIFF
--- a/rma/views/report_rma.xml
+++ b/rma/views/report_rma.xml
@@ -47,23 +47,23 @@
                     <span t-field="doc.name" />
                 </h2>
                 <div class="row mt32 mb32" id="general_information">
-                    <div t-if="doc.origin" class="col-auto mw-100 mb-2">
+                    <div t-if="doc.origin" class="col">
                         <strong>Origin:</strong>
                         <p class="m-0" t-field="doc.origin" />
                     </div>
-                    <div class="col-auto mw-100 mb-2">
+                    <div class="col">
                         <strong>Date:</strong>
                         <p class="m-0" t-field="doc.date" />
                     </div>
-                    <div t-if="doc.deadline" class="col-auto mw-100 mb-2">
+                    <div t-if="doc.deadline" class="col">
                         <strong>Deadline:</strong>
                         <p class="m-0" t-field="doc.deadline" />
                     </div>
-                    <div t-if="doc.user_id" class="col-auto mw-100 mb-2">
+                    <div t-if="doc.user_id" class="col">
                         <strong>Responsible:</strong>
                         <p class="m-0" t-field="doc.user_id" />
                     </div>
-                    <div class="col-auto mw-100 mb-2">
+                    <div class="col">
                         <strong>State:</strong>
                         <p class="m-0">
                             <t t-if="doc.state in ['refunded', 'replaced', 'returned']">
@@ -98,19 +98,19 @@
                 <table class="table table-sm o_main_table table-borderless mt-4">
                     <tbody>
                         <tr t-if="doc.picking_id" name="tr_picking">
-                            <td>Origin delivery</td>
+                            <td class="w-25">Origin delivery</td>
                             <td>
                                 <span t-field="doc.picking_id" />
                             </td>
                         </tr>
                         <tr>
-                            <td>Product</td>
+                            <td class="w-25">Product</td>
                             <td>
                                 <span t-field="doc.product_id" />
                             </td>
                         </tr>
                         <tr>
-                            <td>Quantity</td>
+                            <td class="w-25">Quantity</td>
                             <td>
                                 <span t-field="doc.product_uom_qty" />
                                 <span
@@ -120,7 +120,7 @@
                             </td>
                         </tr>
                         <tr t-if="doc.delivered_qty">
-                            <td>Delivered Quantity</td>
+                            <td class="w-25">Delivered Quantity</td>
                             <td>
                                 <span t-field="doc.delivered_qty" />
                                 <span
@@ -130,7 +130,7 @@
                             </td>
                         </tr>
                         <tr>
-                            <td>Requested operation</td>
+                            <td class="w-25">Requested operation</td>
                             <td>
                                 <span t-field="doc.operation_id" />
                             </td>


### PR DESCRIPTION
This fixes the column width which originally had no gap which could make reading of concatenated values difficult.

This is how it looked like before:

<img width="689" height="249" alt="image" src="https://github.com/user-attachments/assets/b34f8279-9c86-40c5-904c-e031ee47f6c5" />

This is after the fix:

<img width="786" height="246" alt="image" src="https://github.com/user-attachments/assets/3e2ddf9c-f514-454f-ae38-97e06ff19cc3" />