### PR TITLE
[18.0][FIX] rma_sale: Prevent the automatic creation of an extra sales line when validating a delivery picking

### DIFF
--- a/rma_sale/models/rma.py
+++ b/rma_sale/models/rma.py
@@ -260,6 +260,14 @@ class Rma(models.Model):
             vals["sale_line_id"] = move.sale_line_id.id
         return vals
 
+    def _delivery_should_be_grouped(self):
+        # It is important to always return True if there is a linked sales order
+        # so that rma creates a new procurement.group, there by preventing an extra
+        # sales order line from being automatically created once the delivery
+        # picking is done.
+        res = super()._delivery_should_be_grouped()
+        return True if self.order_id else res
+
     def create_replace(self, scheduled_date, warehouse, product, qty, uom):
         # When the procurement group has the sale id set it will propagate to the
         # pickings. This is inconvenient for this operation as when we confirm the

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -199,6 +199,8 @@ class TestRmaSale(TestRmaSaleBase):
         wizard = self._rma_sale_wizard(order)
         rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
         self.assertEqual(rma.order_id, order)
+        rma_group = rma.procurement_group_id
+        self.assertEqual(rma_group.sale_id, order)
         rma.reception_move_id.quantity = rma.product_uom_qty
         rma.reception_move_id.picking_id.button_validate()
         self.assertEqual(rma.state, "received")
@@ -206,10 +208,13 @@ class TestRmaSale(TestRmaSaleBase):
         wizard_form = Form(self.env[res["res_model"]].with_context(**res["context"]))
         wizard = wizard_form.save()
         wizard.action_deliver()
+        self.assertNotEqual(rma.procurement_group_id, rma_group)
+        self.assertFalse(rma.procurement_group_id.sale_id)
         picking = rma.delivery_move_ids.picking_id
         picking.move_ids.quantity = rma.product_uom_qty
         picking.button_validate()
         self.assertEqual(rma.state, "returned")
+        self.assertEqual(len(order.order_line), 1)
         self.assertTrue(rma.can_be_new_rma)
         res = rma.action_create_rma()
         wizard_form = Form(self.env[res["res_model"]].with_context(**res["context"]))
@@ -550,3 +555,28 @@ class TestRmaSale(TestRmaSaleBase):
             rma1.reception_move_id.picking_id, rma2.reception_move_id.picking_id
         )
         self.assertEqual(rma1.procurement_group_id.sale_id, sale_order)
+
+    def test_not_rma_return_grouping_flow(self):
+        self.company.rma_return_grouping = False
+        order = self.sale_order
+        self.assertEqual(len(order.order_line), 1)
+        wizard = self._rma_sale_wizard(order)
+        rma = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
+        rma_group = rma.procurement_group_id
+        self.assertEqual(rma_group.sale_id, order)
+        self.assertEqual(rma.order_id, order)
+        reception_move = rma.reception_move_id
+        reception_move.picking_id.button_validate()
+        self.assertEqual(rma.state, "received")
+        res = rma.action_return()
+        wizard_form = Form(self.env[res["res_model"]].with_context(**res["context"]))
+        wizard = wizard_form.save()
+        wizard.action_deliver()
+        self.assertNotEqual(rma.procurement_group_id, rma_group)
+        self.assertFalse(rma.procurement_group_id.sale_id)
+        picking = rma.delivery_move_ids.picking_id
+        picking.button_validate()
+        self.assertEqual(rma.state, "returned")
+        self.assertFalse(rma.delivery_move_ids.sale_line_id)
+        self.assertFalse(rma.procurement_group_id.sale_id)
+        self.assertEqual(len(order.order_line), 1)


### PR DESCRIPTION
Prevent the automatic creation of an extra sales line when validating a delivery picking

Example use case:
- Disable the company setting "Group RMA returns by shipping address and warehouse".
- Create and confirm a Sale Order.
- Deliver the products.
- Create an RMA from the Sale Order.
- Process the reception.
- Execute Return to customer.
- Validate the outgoing delivery.

Fixes #608

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa