### PR TITLE
[17.0][FIX] rma: Clear context upon confirm to avoid side effects

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -13,6 +13,7 @@ from markupsafe import Markup
 from odoo import _, api, fields, models
 from odoo.exceptions import AccessError, ValidationError
 from odoo.tools import html2plaintext
+from odoo.tools.misc import clean_context
 
 from odoo.addons.stock.models.stock_move import PROCUREMENT_PRIORITIES
 
@@ -806,6 +807,12 @@ class Rma(models.Model):
 
     def action_confirm(self):
         """Invoked when 'Confirm' button in rma form view is clicked."""
+        # It is important to "clear" the default_operation_id key from the context to
+        # prevent an attempt to set that value in the stock.move record that will be
+        # created for the operation_id field if mrp is installed.
+        self = self.with_context(  # pylint: disable=W8121
+            clean_context(self.env.context)
+        )
         self._ensure_required_fields()
         self = self.filtered(lambda rma: rma.state == "draft")
         if not self:


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/rma/pull/610

Clear `default_operation_id` from the context upon confirm to avoid side effects

Steps to reproduce:
- Install `rma` + `mrp`
- Modify the ID of an rma operation (e.g., refund) in the database and set it to 90. The goal is to define an ID that does not exist in mrp_routing_workcenter table.
- Manually create an RMA using any product and select the operation from the previous step.
- Go to RMA > Overview and click on the previous operation from the Kanban view > Draft to access the previously created RMA.
- Click the Confirm button

Fixes https://github.com/OCA/rma/issues/523

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa