### PR TITLE
[18.0][IMP] rma: Allow users without RMA permissions to confirm stock moves not related to RMA

### DIFF
--- a/rma/models/stock_move.py
+++ b/rma/models/stock_move.py
@@ -103,11 +103,16 @@ class StockMove(models.Model):
     def _prepare_merge_moves_distinct_fields(self):
         """The main use is that launched delivery RMAs doesn't merge
         two moves if they are linked to a different RMAs.
+        Only add the fields if they are set, to prevent an error caused
+        by a stock user without RMA permissions when confirming a picking.
         """
-        return super()._prepare_merge_moves_distinct_fields() + [
-            "rma_id",
-            "rma_receiver_ids",
-        ]
+        extra_fields = []
+        _self = self.sudo()
+        if any(move.rma_id for move in _self):
+            extra_fields.append("rma_id")
+        if any(move.rma_receiver_ids for move in _self):
+            extra_fields.append("rma_receiver_ids")
+        return super()._prepare_merge_moves_distinct_fields() + extra_fields
 
     def _prepare_move_split_vals(self, qty):
         """Intended to the backport of picking linked to RMAs propagates the

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -1092,6 +1092,25 @@ class TestRmaCase(TestRma):
         self.assertEqual(len((rma1 | rma2).reception_move_id.picking_id), 1)
         self.assertEqual(len((rma1 | rma2 | rma3).reception_move_id.picking_id), 2)
 
+    def test_stock_user_can_confirm_picking_without_rma_acl(self):
+        picking_form = Form(
+            self.env["stock.picking"].with_context(
+                default_picking_type_id=self.warehouse_company.out_type_id.id
+            )
+        )
+        picking_form.partner_id = self.partner
+        with picking_form.move_ids_without_package.new() as move:
+            move.product_id = self.product
+            move.product_uom_qty = 1
+        picking = picking_form.save()
+        user_stock = new_test_user(
+            self.env,
+            login="test-user_stock",
+            groups="stock.group_stock_user",
+        )
+        picking.with_user(user_stock).action_confirm()
+        self.assertIn(picking.state, ("confirmed", "assigned", "waiting"))
+
     def test_copy_operation(self):
         operation = self.env.ref("rma.rma_operation_refund")
         new_operation = operation.copy()


### PR DESCRIPTION
Allow users without RMA permissions to confirm stock moves not related to RMA

@Tecnativa