### PR TITLE
[18.0][IMP] rma: Add delivered_qty_done + remaining_qty_to_done - #623

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -242,6 +242,11 @@ class Rma(models.Model):
         compute="_compute_delivered_qty",
         store=True,
     )
+    delivered_qty_done = fields.Float(
+        digits="Product Unit of Measure",
+        compute="_compute_delivered_qty_done",
+        store=True,
+    )
     can_be_returned = fields.Boolean(
         compute="_compute_can_be_returned",
     )
@@ -256,6 +261,11 @@ class Rma(models.Model):
     )
     remaining_qty = fields.Float(
         string="Remaining delivered qty",
+        digits="Product Unit of Measure",
+        compute="_compute_remaining_qty",
+    )
+    remaining_qty_to_done = fields.Float(
+        string="Remaining delivered qty to done",
         digits="Product Unit of Measure",
         compute="_compute_remaining_qty",
     )
@@ -368,17 +378,12 @@ class Rma(models.Model):
         "product_uom",
     )
     def _compute_delivered_qty(self):
-        """Compute 'delivered_qty' and 'delivered_qty_done' fields.
+        """Compute 'delivered_qty' field.
 
         delivered_qty: represents the quantity delivery or to be
         delivery. For each move in delivery_move_ids the quantity done
         is taken, if it is empty the reserved quantity is taken,
         otherwise the initial demand is taken.
-
-        delivered_qty_done: represents the quantity delivered and done.
-        For each 'done' move in delivery_move_ids the quantity done is
-        taken. This field is used to control when the RMA cam be set
-        to 'delivered' state.
         """
         for record in self:
             delivered_qty = 0.0
@@ -396,7 +401,33 @@ class Rma(models.Model):
                     )
             record.delivered_qty = delivered_qty
 
-    @api.depends("product_uom_qty", "delivered_qty")
+    @api.depends(
+        "delivery_move_ids",
+        "delivery_move_ids.state",
+        "delivery_move_ids.scrapped",
+        "delivery_move_ids.quantity",
+        "delivery_move_ids.product_uom",
+    )
+    def _compute_delivered_qty_done(self):
+        """Compute 'delivered_qty_done' field.
+
+        delivered_qty_done: represents the quantity delivered and done.
+        For each 'done' move in delivery_move_ids the quantity done is
+        taken. This field is used to control when the RMA can be set
+        to 'delivered' state.
+        """
+        for record in self:
+            delivered_qty_done = 0.0
+            for move in record.delivery_move_ids.filtered(
+                lambda r: r.state == "done" and not r.scrapped and r.quantity
+            ):
+                quantity = move.product_uom._compute_quantity(
+                    move.quantity, record.product_uom
+                )
+                delivered_qty_done += quantity
+            record.delivered_qty_done = delivered_qty_done
+
+    @api.depends("product_uom_qty", "delivered_qty", "delivered_qty_done")
     def _compute_remaining_qty(self):
         """Compute 'remaining_qty' field.
 
@@ -405,6 +436,7 @@ class Rma(models.Model):
         """
         for r in self:
             r.remaining_qty = r.product_uom_qty - r.delivered_qty
+            r.remaining_qty_to_done = r.product_uom_qty - r.delivered_qty_done
 
     @api.depends("state", "operation_id", "operation_id.action_create_refund")
     def _compute_can_be_refunded(self):
@@ -497,7 +529,7 @@ class Rma(models.Model):
                 and rma.remaining_qty > 0
             ) or (rma.state != "finished" and not rma.manual_finish_allowed)
 
-    @api.depends("product_uom_qty", "state", "remaining_qty")
+    @api.depends("product_uom_qty", "state", "remaining_qty", "remaining_qty_to_done")
     def _compute_can_be_split(self):
         """Compute 'can_be_split'. This field controls the
         visibility of 'Split' button in the rma form view and
@@ -514,10 +546,10 @@ class Rma(models.Model):
             else:
                 r.can_be_split = False
 
-    @api.depends("state")
+    @api.depends("remaining_qty_to_done", "state")
     def _compute_can_be_locked(self):
         for r in self:
-            r.can_be_locked = r.remaining_qty > 0 and r.state in [
+            r.can_be_locked = r.remaining_qty_to_done > 0 and r.state in [
                 "received",
                 "waiting_return",
                 "waiting_replacement",
@@ -1207,7 +1239,7 @@ class Rma(models.Model):
         self._ensure_can_be_split()
         self._ensure_qty_to_extract(qty, uom)
         self.product_uom_qty -= uom._compute_quantity(qty, self.product_uom)
-        if self.remaining_qty <= 0:
+        if self.remaining_qty_to_done <= 0:
             if self.state == "waiting_return":
                 self.state = "returned"
             elif self.state == "waiting_replacement":
@@ -1634,7 +1666,10 @@ class Rma(models.Model):
         [stock.move]._action_cancel
         """
         rma = self.filtered(
-            lambda r: (r.state == "waiting_replacement" and 0 >= r.remaining_qty)
+            lambda r: (
+                r.state == "waiting_replacement"
+                and 0 >= r.remaining_qty_to_done == r.remaining_qty
+            )
         )
         if rma:
             rma.write({"state": "replaced"})
@@ -1642,7 +1677,7 @@ class Rma(models.Model):
     def update_returned_state(self):
         """Invoked by [stock.move]._action_done"""
         rma = self.filtered(
-            lambda r: (r.state == "waiting_return" and r.remaining_qty <= 0)
+            lambda r: (r.state == "waiting_return" and r.remaining_qty_to_done <= 0)
         )
         if rma:
             rma.write({"state": "returned"})

--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -585,6 +585,8 @@ class TestRmaCase(TestRma):
         self.assertFalse(rma.can_be_replaced)
         self.assertEqual(rma.delivered_qty, 2)
         self.assertEqual(rma.remaining_qty, 8)
+        self.assertEqual(rma.delivered_qty_done, 0)
+        self.assertEqual(rma.remaining_qty_to_done, 10)
         first_move = rma.delivery_move_ids
         picking = first_move.picking_id
         picking.action_cancel()
@@ -614,11 +616,15 @@ class TestRmaCase(TestRma):
         self.assertTrue(new_picking.state, "waiting")
         self.assertEqual(rma.delivered_qty, 10)
         self.assertEqual(rma.remaining_qty, 0)
+        self.assertEqual(rma.delivered_qty_done, 0)
+        self.assertEqual(rma.remaining_qty_to_done, 10)
         second_move.quantity = 10
         new_picking.button_validate()
         self.assertEqual(new_picking.state, "done")
         self.assertEqual(rma.delivered_qty, 10)
         self.assertEqual(rma.remaining_qty, 0)
+        self.assertEqual(rma.delivered_qty_done, 10)
+        self.assertEqual(rma.remaining_qty_to_done, 0)
         # The RMA is now in 'replaced' state
         self.assertEqual(rma.state, "replaced")
         self.assertFalse(rma.can_be_refunded)
@@ -651,6 +657,8 @@ class TestRmaCase(TestRma):
         self.assertTrue(rma.can_be_returned)
         self.assertEqual(rma.delivered_qty, 2)
         self.assertEqual(rma.remaining_qty, 8)
+        self.assertEqual(rma.delivered_qty_done, 0)
+        self.assertEqual(rma.remaining_qty_to_done, 10)
         first_move = rma.delivery_move_ids
         picking = first_move.picking_id
         # Validate the picking
@@ -659,6 +667,8 @@ class TestRmaCase(TestRma):
         self.assertEqual(picking.state, "done")
         self.assertEqual(rma.delivered_qty, 2)
         self.assertEqual(rma.remaining_qty, 8)
+        self.assertEqual(rma.delivered_qty_done, 2)
+        self.assertEqual(rma.remaining_qty_to_done, 8)
         # Return the remaining quantity to the customer
         delivery_form = Form(
             self.env["rma.delivery.wizard"].with_context(
@@ -672,6 +682,8 @@ class TestRmaCase(TestRma):
         second_move.quantity = 8
         self.assertEqual(rma.delivered_qty, 10)
         self.assertEqual(rma.remaining_qty, 0)
+        self.assertEqual(rma.delivered_qty_done, 2)
+        self.assertEqual(rma.remaining_qty_to_done, 8)
         self.assertEqual(rma.state, "waiting_return")
         # remaining_qty is 0 but rma is not set to 'returned' until
         picking_2 = second_move.picking_id
@@ -679,6 +691,8 @@ class TestRmaCase(TestRma):
         self.assertEqual(picking_2.state, "done")
         self.assertEqual(rma.delivered_qty, 10)
         self.assertEqual(rma.remaining_qty, 0)
+        self.assertEqual(rma.delivered_qty_done, 10)
+        self.assertEqual(rma.remaining_qty_to_done, 0)
         # The RMA is now in 'returned' state
         self.assertEqual(rma.state, "returned")
         self.assertFalse(rma.can_be_refunded)
@@ -896,6 +910,8 @@ class TestRmaCase(TestRma):
         self.assertEqual(new_rma.origin_split_rma_id, rma)
         self.assertEqual(new_rma.delivered_qty, 0)
         self.assertEqual(new_rma.remaining_qty, 6)
+        self.assertEqual(new_rma.delivered_qty_done, 0)
+        self.assertEqual(new_rma.remaining_qty_to_done, 6)
         self.assertEqual(new_rma.state, "received")
         self.assertFalse(new_rma.can_be_refunded)
         self.assertTrue(new_rma.can_be_returned)
@@ -1096,3 +1112,43 @@ class TestRmaCase(TestRma):
         operation = self.env.ref("rma.rma_operation_refund")
         new_operation = operation.copy()
         self.assertEqual(new_operation.name, "Refund (copy)")
+
+    def test_split_rma_returned(self):
+        rma = self._create_confirm_receive(self.partner, self.product, 2, self.rma_loc)
+        self.assertEqual(rma.state, "received")
+        delivery_form = Form(
+            self.env["rma.delivery.wizard"].with_context(
+                active_ids=rma.ids,
+                rma_delivery_type="return",
+            )
+        )
+        delivery_form.product_uom_qty = 1
+        delivery_wizard = delivery_form.save()
+        delivery_wizard.action_deliver()
+        delivery_move = rma.delivery_move_ids
+        delivery_picking = delivery_move.picking_id
+        delivery_move.quantity = 1
+        self.assertEqual(delivery_picking.state, "assigned")
+        self.assertEqual(rma.state, "waiting_return")
+        self.assertTrue(rma.can_be_split)
+        split_wizard = (
+            self.env["rma.split.wizard"]
+            .with_context(
+                active_id=rma.id,
+                active_ids=rma.ids,
+            )
+            .create({})
+        )
+        res = split_wizard.action_split()
+        rma_extra = self.env[res["res_model"]].browse(res["res_id"])
+        self.assertEqual(rma_extra.state, "received")
+        # Because the outgoing picking has not been validated yet,
+        # the original RMA must remain in Waiting for return.
+        self.assertEqual(rma.state, "waiting_return")
+        # Validate the outgoing picking after the split.
+        # This marks the delivered unit as done and changes the original
+        # RMA to Returned.
+        delivery_picking.button_validate()
+        self.assertEqual(delivery_picking.state, "done")
+        self.assertEqual(rma.delivered_qty_done, 1)
+        self.assertEqual(rma.state, "returned")


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/rma/pull/623

Add `delivered_qty_done` + `remaining_qty_to_done`

The fields were unnecessarily removed in https://github.com/OCA/rma/commit/9cc5bca1532edc9c8de4fd2e0d0a6cb4e0bb8161 but already existed in v16

The `_compute_delivered_qty_done()` method was added because the `_compute_delivered_qty()` method could not be used with compute_sudo (inconsistent across fields) and the same method could not be used for fields with store=True and store=False

Fixes #615 

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa