### PR TITLE
[18][rma_repair][FIX] set product to repair location with RMA location and keep default location for components

### DIFF
--- a/rma_repair/models/rma.py
+++ b/rma_repair/models/rma.py
@@ -62,7 +62,7 @@ class RMA(models.Model):
         return {
             "default_rma_ids": [self.id],
             "default_product_id": self.product_id.id,
-            "default_location_id": self.location_id.id,
+            "default_product_location_src_id": self.location_id.id,
             "default_partner_id": self.partner_id.id,
             "default_product_qty": self.product_uom_qty,
             "default_product_uom": self.product_uom.id,

--- a/rma_repair/tests/test_rma_repair_order.py
+++ b/rma_repair/tests/test_rma_repair_order.py
@@ -19,7 +19,7 @@ class RMARepairOrderTest(TestRma):
             cls.env["repair.order"].with_context(
                 default_product_id=cls.rma.product_id.id,
                 default_rma_ids=[cls.rma.id],
-                default_location_id=cls.rma.location_id.id,
+                default_product_location_src_id=cls.rma.location_id.id,
             )
         )
         cls.repair_order = repair_form.save()
@@ -37,7 +37,7 @@ class RMARepairOrderTest(TestRma):
         expected = {
             "default_rma_ids": [self.rma.id],
             "default_product_id": self.rma.product_id.id,
-            "default_location_id": self.rma.location_id.id,
+            "default_product_location_src_id": self.rma.location_id.id,
             "default_partner_id": self.rma.partner_id.id,
             "default_product_qty": self.rma.product_uom_qty,
             "default_product_uom": self.rma.product_uom.id,


### PR DESCRIPTION
On a demo database, if you create a RMA with the repair operation, you will have a Reception on RMA location and then the repair order will be configured to take the product in WH/Stock and take the components in RMA location, it should be the contrary IMO.

I think maybe this is because Odoo introduced a change in v18 and it was missed during migration.
In Odoo 17, we only have `location_id` with description about the product to repair : https://github.com/odoo/odoo/blob/17.0/addons/repair/models/repair.py#L105C30-L105C51
While in Odoo 18 ,the same field has a description about the component https://github.com/odoo/odoo/blob/18.0/addons/repair/models/repair.py#L118
And there is a new field to replace the v17 `location_id` for product to repair : https://github.com/odoo/odoo/blob/18.0/addons/repair/models/repair.py#L130

What do you think @victoralmau @pedrobaeza 