### PR TITLE
[18][rma][FIX] Allow partial reception when multiple rma are grouped (batch)

### DIFF
--- a/rma/models/stock_move.py
+++ b/rma/models/stock_move.py
@@ -70,6 +70,7 @@ class StockMove(models.Model):
                     precision_digits=qty_prec,
                 )
                 != 0
+                and float_compare(move.quantity, 0, precision_digits=qty_prec != 0)
             ):
                 raise ValidationError(
                     self.env._(


### PR DESCRIPTION
If I create a batch with 2 RMA (with rma_batch installed), both RMA are grouped in a reception.
If I try to receive one of the RMA and create a backorder, I have the error message : 
_The quantity done for the product 'XXX' must be equal to its initial demand because the stock move is linked to an RMA (RMAXXX)._

This happens because when you validate a picking from the UI, `_action_done` is called on all lines (`stock.move`) and later on (in stock modules), Odoo does not proceed the lines which do not have `stock.move.line`.

So the fix check if we try to really proceed the line (quantity != 0) before doing a raise.