### PR TITLE
[18.0][FIX] rma + rma_sale: Defining the correct partner fields in the RMA

### DIFF
--- a/rma/tests/test_rma.py
+++ b/rma/tests/test_rma.py
@@ -339,7 +339,14 @@ class TestRmaCase(TestRma):
 
     def test_confirm_and_receive_and_return(self):
         self.company.rma_new_rma_button_from_rma = True
+        partner_shipping = self.env["res.partner"].create(
+            {
+                "name": "Test partner shipping",
+                "parent_id": self.partner.id,
+            }
+        )
         rma = self._create_rma(self.partner, self.product, 10, self.rma_loc)
+        rma.partner_shipping_id = partner_shipping
         rma.action_confirm()
         self.assertEqual(rma.reception_move_id.picking_id.state, "assigned")
         self.assertEqual(rma.reception_move_id.product_id, rma.product_id)
@@ -372,6 +379,8 @@ class TestRmaCase(TestRma):
         wizard = wizard_form.save()
         new_rma = wizard.create_rma()
         self.assertTrue(new_rma)
+        self.assertEqual(new_rma.partner_id, rma.partner_id)
+        self.assertEqual(new_rma.partner_shipping_id, rma.partner_shipping_id)
         self.assertEqual(new_rma.state, "confirmed")
         self.assertEqual(new_rma.operation_id, rma.operation_id)
         self.assertEqual(rma.rma_count, 1)

--- a/rma/wizard/stock_picking_return.py
+++ b/rma/wizard/stock_picking_return.py
@@ -43,7 +43,7 @@ class ReturnPickingLine(models.TransientModel):
                 [("company_id", "=", self.move_id.picking_id.company_id.id)],
                 limit=1,
             )
-        return {
+        vals = {
             "move_id": self.move_id.id,
             "product_id": self.move_id.product_id.id,
             "product_uom_qty": self.quantity,
@@ -52,6 +52,15 @@ class ReturnPickingLine(models.TransientModel):
             "operation_id": self.rma_operation_id.id,
             "return_product_id": self.return_product_id.id,
         }
+        # RMA from RMA compatibility
+        rma = self.move_id.rma_id
+        if rma:
+            vals.update(
+                partner_id=rma.partner_id.id,
+                partner_shipping_id=rma.partner_shipping_id.id,
+                partner_invoice_id=rma.partner_invoice_id.id,
+            )
+        return vals
 
 
 class ReturnPicking(models.TransientModel):

--- a/rma_inter_company/tests/test_rma_inter_company.py
+++ b/rma_inter_company/tests/test_rma_inter_company.py
@@ -319,6 +319,7 @@ class TestRmaInterCompany(TestRmaInterCompanyBase):
         wizard_form.operation_id = operation_refund
         wizard = wizard_form.save()
         rma_b_extra = self.env["rma"].browse(wizard.create_and_open_rma()["res_id"])
+        self.assertEqual(rma_b_extra.partner_id, rma_b.partner_id)
         self.assertEqual(rma_b_extra.state, "confirmed")
         self.assertEqual(rma_b_extra.company_id, self.company_b)
         self.assertEqual(rma_b_extra.operation_id, operation_refund)
@@ -326,6 +327,7 @@ class TestRmaInterCompany(TestRmaInterCompanyBase):
         self.assertEqual(rma_b_extra.move_id, rma_b.delivery_move_ids)
         self.assertTrue(rma_b_extra.intercompany_rma_id)
         rma_a_extra = rma_b_extra.intercompany_rma_id
+        self.assertEqual(rma_a_extra.partner_id, rma_a.partner_id)
         self.assertEqual(rma_a_extra.state, "confirmed")
         self.assertEqual(rma_a_extra.company_id, self.company_a)
         self.assertEqual(rma_a_extra.operation_id, operation_refund)

--- a/rma_sale/tests/test_rma_sale.py
+++ b/rma_sale/tests/test_rma_sale.py
@@ -89,6 +89,32 @@ class TestRmaSale(TestRmaSaleBase):
             self.order_out_picking.move_ids, self.order_line.get_delivery_move()
         )
 
+    def test_create_rma_from_picking(self):
+        partner_shipping = self.env["res.partner"].create(
+            {
+                "name": "Test partner shipping",
+                "parent_id": self.partner.id,
+            }
+        )
+        self.sale_order.partner_shipping_id = partner_shipping
+        return_wizard_form = Form(
+            self.env["stock.return.picking"]
+            .sudo()
+            .with_context(
+                active_id=self.order_out_picking.id,
+                active_model=self.order_out_picking._name,
+            )
+        )
+        return_wizard_form.create_rma = True
+        return_wizard_form.rma_operation_id = self.operation
+        return_wizard = return_wizard_form.save()
+        res = return_wizard.action_create_returns_all()
+        new_picking = self.env[res["res_model"]].browse(res["res_id"])
+        new_rma = new_picking.move_ids.rma_receiver_ids
+        self.assertTrue(new_rma)
+        self.assertEqual(new_rma.partner_id, self.partner)
+        self.assertEqual(new_rma.partner_shipping_id, partner_shipping)
+
     def test_rma_sale_computes_onchange(self):
         rma = self.env["rma"].new()
         # No m2m values when everything is selectable

--- a/rma_sale/wizard/stock_picking_return.py
+++ b/rma_sale/wizard/stock_picking_return.py
@@ -23,3 +23,20 @@ class ReturnPicking(models.TransientModel):
         if sale_order:
             vals["order_id"] = sale_order.id
         return vals
+
+
+class ReturnPickingLine(models.TransientModel):
+    _inherit = "stock.return.picking.line"
+
+    def _prepare_rma_vals(self):
+        vals = super()._prepare_rma_vals()
+        # If the RMA is created from a picking order linked to a sales order, the
+        # partner data in the RMA must be correct
+        order = self.move_id.sale_line_id.order_id
+        if order:
+            vals.update(
+                partner_id=order.partner_id.id,
+                partner_shipping_id=order.partner_shipping_id.id,
+                partner_invoice_id=order.partner_invoice_id.id,
+            )
+        return vals


### PR DESCRIPTION
Changes done:
- [x] `rma`: Defining the correct partner fields in the RMA
- [x] `rma_sale`: Define the appropriate partner fields when creating an RMA
- [x] `rma_inter_company`: Improve test in the process of creating an RMA from another one

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT64455